### PR TITLE
DM-17879: Fix RegistryApi put/post/patch/delete methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Change log
 ##########
 
+0.1.1 (2019-02-13)
+==================
+
+Several fixes:
+
+- ``RegistryApi.put`` was doing a ``PATCH`` behind the scenes. That's fixed now.
+- The ``RegistryApi.put``, ``patch``, and ``delete`` methods weren't returning data. That's fixed now as well.
+- All of the RegistryApi's low-level HTTP methods have more thorough unit testing now to avoid these issues in the future.
+
+:jirab:`DM-17879`
+
 0.1.0 (2019-01-30)
 ==================
 

--- a/kafkit/registry/sansio.py
+++ b/kafkit/registry/sansio.py
@@ -285,7 +285,7 @@ class RegistryApi(metaclass=abc.ABCMeta):
             Raised if the server returns a 5XX status because something is
             wrong with the server itself.
         """
-        data = await self._make_request("PATCH", url, url_vars, data)
+        data = await self._make_request("PUT", url, url_vars, data)
 
     async def delete(self, url, url_vars=dict(), *, data=b""):
         """Send an HTTP DELETE request.

--- a/kafkit/registry/sansio.py
+++ b/kafkit/registry/sansio.py
@@ -252,6 +252,7 @@ class RegistryApi(metaclass=abc.ABCMeta):
             wrong with the server itself.
         """
         data = await self._make_request("PATCH", url, url_vars, data)
+        return data
 
     async def put(self, url, url_vars=dict(), data=b""):
         """Send an HTTP PUT request.
@@ -286,6 +287,7 @@ class RegistryApi(metaclass=abc.ABCMeta):
             wrong with the server itself.
         """
         data = await self._make_request("PUT", url, url_vars, data)
+        return data
 
     async def delete(self, url, url_vars=dict(), *, data=b""):
         """Send an HTTP DELETE request.
@@ -320,6 +322,7 @@ class RegistryApi(metaclass=abc.ABCMeta):
             wrong with the server itself.
         """
         data = await self._make_request("DELETE", url, url_vars, data)
+        return data
 
     @staticmethod
     def _prep_schema(schema):

--- a/tests/test_registry_sansio.py
+++ b/tests/test_registry_sansio.py
@@ -121,6 +121,7 @@ async def test_registryapi_get_empty():
     # Check headers
     assert client.headers['accept'] == make_headers()['accept']
     assert client.headers['content-length'] == '0'
+    assert client.method == 'GET'
 
 
 @pytest.mark.asyncio
@@ -135,6 +136,64 @@ async def test_registryapi_get_json():
                                 url_vars={'subject': 'helloworld'})
 
     assert response == expected_data
+    assert client.method == 'GET'
+
+
+@pytest.mark.asyncio
+async def test_registryapi_post():
+    """Test RegistryApi.post().
+    """
+    expected_data = {'key': 'value'}
+    client = MockRegistryApi(
+        url='http://registry:8081',
+        body=json.dumps(expected_data).encode('utf-8'))
+    response = await client.post('/a{/b}', url_vars={'b': 'hello'}, data={})
+
+    assert response == expected_data
+    assert client.method == 'POST'
+    assert client.url == 'http://registry:8081/a/hello'
+
+
+@pytest.mark.asyncio
+async def test_registryapi_patch():
+    """Test RegistryApi.patch().
+    """
+    expected_data = {'key': 'value'}
+    client = MockRegistryApi(
+        url='http://registry:8081',
+        body=json.dumps(expected_data).encode('utf-8'))
+    response = await client.patch('/a{/b}', url_vars={'b': 'hello'}, data={})
+
+    assert response == expected_data
+    assert client.method == 'PATCH'
+    assert client.url == 'http://registry:8081/a/hello'
+
+
+@pytest.mark.asyncio
+async def test_registryapi_put():
+    """Test RegistryApi.put().
+    """
+    expected_data = {'key': 'value'}
+    client = MockRegistryApi(
+        url='http://registry:8081',
+        body=json.dumps(expected_data).encode('utf-8'))
+    response = await client.put('/a{/b}', url_vars={'b': 'hello'}, data={})
+
+    assert response == expected_data
+    assert client.method == 'PUT'
+    assert client.url == 'http://registry:8081/a/hello'
+
+
+@pytest.mark.asyncio
+async def test_registryapi_delete():
+    """Test RegistryApi.put().
+    """
+    client = MockRegistryApi(
+        url='http://registry:8081')
+    await client.delete('/a{/b}', url_vars={'b': 'hello'})
+
+    assert client.method == 'DELETE'
+    assert client.url == 'http://registry:8081/a/hello'
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- `RegistryApi.put` was doing a `PATCH` behind the scenes. That's fixed now.
- The `RegistryApi.put`, `patch`, and `delete` methods weren't returning data. That's fixed now.
- Added testing for all the `RegistyApi` HTTP methods.