### PR TITLE
DM-23797: Add a schema manager based on the "record name" subject naming strategy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change log
 - We've added a ``kafkit.ssl`` module to help connect to Kafka brokers over TLS.
   The associated documentation includes a tutorial for working with the SSL certificates generated in a Kafka cluster managed by `Strimzi <https://strimzi.io>`__.
 
+- The brand-new ``kafkit.registry.manager.RecordNameSchemaManager`` provides a streamlined workflow for serializing Avro messages using Avro schemas that are maintained in your app's codebase.
+  The manager handles schema registration for you.
+  To serialize a message, you simply need to provide the data and the name of the schema.
+
+- A new ``kafkit.registry.sansio.CompatibilityType`` Enum helps you write use valid Schema Registry compatibility types.
+
 - We've significantly improved Kafkit's packaging and infrastructure:
 
   - Migrate packaging metadata from ``setup.py`` to ``setup.cfg``.

--- a/README.rst
+++ b/README.rst
@@ -4,18 +4,16 @@ Kafkit
 
 Kafkit helps you write Kafka producers and consumers in Python with asyncio:
 
-- Kafkit integrates aiokafka_ consumers and producers with the `Confluent Schema Registry`_.
-  The ``kafkit.registry.Deserializer`` class can deserialize messages with any schema that's registered in a `Confluent Schema Registry`_.
-  The ``kafkit.registry.Serializer`` class can serialize Python objects against a single Avro schema, while the ``kafkit.registry.PolySerializer`` class is flexible enough to handle multiple schemas.
+- Kafkit provides a client for the Confluent Schema Registry's HTTP API.
+  The ``RegistryApi`` client includes both high-level methods for managing subjects and schemas in a Registry, and direct low-level access to HTTP methods (GET, POST, PUT, PATCH, and DELETE).
+  The high-level methods use caching so you can use the client as an integral part of your application's schema management.
+  ``RegistryApi`` is implemented around aiohttp_, but since the base class is designed with a `sans IO architecture <https://sans-io.readthedocs.io>`__, a Registry client can be implemented with any asyncio HTTP library.
 
-- Kafkit provides Python APIs for working with the Confluent Schema Registry's HTTP API.
-  The ``kafkit.registry.aiohttp.RegistryApi`` client includes high-level methods that manage subjects and their schemas in a registry.
-  These methods are cached so that the ``kafkit.registry.aiohttp.RegistryApi`` client can be an integral part of your application's schema management.
-  Additionally, ``kafkit.registry.aiohttp.RegistryApi`` includes low-level HTTP methods (GET, POST, PUT, PATCH, DELETE) so you can work directly with the Confluent Schema Registry API if you want.
+- Kafkit provides Avro message serializers and deserializers that integrate with the `Confluent Schema Registry`_: ``Deserializer``, ``Serializer``, and ``PolySerializer``.
 
-- ``kafkit.registry.aiohttp.RegistryApi`` is implemented with aiohttp_, but that's not the only implementation.
-  Kafkit subscribes to the `sans IO architecture <https://sans-io.readthedocs.io>`__ (`gidgethub <https://gidgethub.readthedocs.io/en/latest/>`__ is a popular example) meaning that you can subclass ``kafkit.registry.sansio.RegistryApi`` to integrate with your favorite HTTP client library.
-  The ``kafkit.registry.sansio.MockRegistryApi`` is a mock client that you can use in your app's unit tests.
+- The ``RecordNameSchemaManager`` is a streamlined tool for serializing messages using the schemas maintained by your app, while also integrating with the `Confluent Schema Registry`_.
+
+- The ``kafkit.ssl`` module helps you connect to SSL-secured Kafka brokers.
 
 Learn more about Kafkit at https://kafkit.lsst.io.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,59 @@
+version: "3"
+services:
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.3.2
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      - "ZOOKEEPER_CLIENT_PORT=2181"
+      - "ZOOKEEPER_TICK_TIME=2000"
+
+  broker:
+    image: confluentinc/cp-kafka:5.3.2 # Kafka 2.3
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "29092:29092"
+      - "9092:9092"
+    environment:
+      - "KAFKA_BROKER_ID=1"
+      - "KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181"
+      - "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
+      - "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092"
+      - "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1"
+      - "KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0"
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:5.3.2
+    hostname: schema-registry
+    container_name: schema-registry
+    depends_on:
+      - zookeeper
+      - broker
+    ports:
+      - "8081:8081"
+    environment:
+      - "SCHEMA_REGISTRY_HOST_NAME=schema-registry"
+      - "SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181"
+      - "SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:8081"
+
+  rest-proxy:
+    image: confluentinc/cp-kafka-rest:5.4.1
+    depends_on:
+      - zookeeper
+      - broker
+      - schema-registry
+    ports:
+      - 8082:8082
+    hostname: rest-proxy
+    container_name: rest-proxy
+    environment:
+      - "KAFKA_REST_HOST_NAME=rest-proxy"
+      - "KAFKA_REST_BOOTSTRAP_SERVERS=broker:29092"
+      - "KAFKA_REST_LISTENERS=http://0.0.0.0:8082"
+      - "KAFKA_REST_SCHEMA_REGISTRY_URL=http://schema-registry:8081"

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,9 @@ Kafkit API reference
 .. automodapi:: kafkit.registry.aiohttp
    :no-inheritance-diagram:
 
+.. automodapi:: kafkit.registry.manager
+   :no-inheritance-diagram:
+
 .. automodapi:: kafkit.registry.sansio
    :no-inheritance-diagram:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,9 +9,11 @@ rst_epilog = """
 .. _aiohttp: https://aiohttp.readthedocs.io/en/stable/
 .. _aiokafka: https://aiokafka.readthedocs.io/en/stable/
 .. _Confluent Schema Registry: https://docs.confluent.io/current/schema-registry/docs/index.html
+.. _Confluent Wire Format: https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
 .. _mypy: http://www.mypy-lang.org
 .. _pre-commit: https://pre-commit.com
 .. _pytest: https://docs.pytest.org/en/latest/
+.. _Schema Evolution and Compatibility: https://docs.confluent.io/current/schema-registry/avro.html
 .. _Strimzi: https://strimzi.io
 .. _tox: https://tox.readthedocs.io/en/latest/
 """

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,18 +4,16 @@ Kafkit
 
 Kafkit helps you write Kafka producers and consumers in Python with asyncio:
 
-- Kafkit integrates aiokafka_ consumers and producers with the `Confluent Schema Registry`_.
-  The `~kafkit.registry.Deserializer` class can deserialize messages with any schema that's registered in a `Confluent Schema Registry`_.
-  The `~kafkit.registry.Serializer` class can serialize Python objects against a single Avro schema, while the `~kafkit.registry.PolySerializer` class is flexible enough to handle multiple schemas.
+- Kafkit provides a client for the Confluent Schema Registry's HTTP API.
+  The `~kafkit.registry.aiohttp.RegistryApi` client includes both high-level methods for managing subjects and schemas in a Registry, and direct low-level access to HTTP methods (GET, POST, PUT, PATCH, and DELETE).
+  The high-level methods use caching so you can use the client as an integral part of your application's schema management.
+  `~kafkit.registry.aiohttp.RegistryApi` is implemented around aiohttp_, but since the base class is designed with a `sans IO architecture <https://sans-io.readthedocs.io>`__, a Registry client can be implemented with any asyncio HTTP library.
 
-- Kafkit provides Python APIs for working with the Confluent Schema Registry's HTTP API.
-  The `~kafkit.registry.aiohttp.RegistryApi` client includes high-level methods that manage subjects and their schemas in a registry.
-  These methods are cached so that the `~kafkit.registry.aiohttp.RegistryApi` client can be an integral part of your application's schema management.
-  Additionally, `~kafkit.registry.aiohttp.RegistryApi` includes low-level HTTP methods (GET, POST, PUT, PATCH, DELETE) so you can work directly with the Confluent Schema Registry API if you want.
+- Kafkit provides Avro message serializers and deserializers that integrate with the `Confluent Schema Registry`_: `~kafkit.registry.Deserializer`, `~kafkit.registry.Serializer`, and `~kafkit.registry.PolySerializer`.
 
-- `kafkit.registry.aiohttp.RegistryApi` is implemented with aiohttp_, but that's not the only implementation.
-  Kafkit subscribes to the `sans IO architecture <https://sans-io.readthedocs.io>`_ (`gidgethub <https://gidgethub.readthedocs.io/en/latest/>`_ is a popular example) meaning that you can subclass `kafkit.registry.sansio.RegistryApi` to integrate with your favorite HTTP client library.
-  The `kafkit.registry.sansio.MockRegistryApi` is a mock client that you can use in your app's unit tests.
+- The `~kafkit.registry.manager.RecordNameSchemaManager` is a streamlined tool for serializing messages using the schemas maintained by your app, while also integrating with the `Confluent Schema Registry`_.
+
+- The `kafkit.ssl` module helps you connect to SSL-secured Kafka brokers.
 
 Installation
 ============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,9 @@ User guide
 ==========
 
 .. toctree::
+   :maxdepth: 2
 
+   recordnameschemamanager-howto
    strimzi-ssl-howto
 
 API reference

--- a/docs/recordnameschemamanager-howto.rst
+++ b/docs/recordnameschemamanager-howto.rst
@@ -1,0 +1,148 @@
+.. |RecordNameSchemaManager| replace:: `~kafkit.registry.manager.RecordNameSchemaManager`
+
+#################################
+Using the RecordNameSchemaManager
+#################################
+
+The |RecordNameSchemaManager| is an opinionated tool for managing Avro Schemas with the `Confluent Schema Registry`_ and for serializing data using those schemas.
+This page will help you understand what the |RecordNameSchemaManager| does and how to add the |RecordNameSchemaManager| into your application.
+
+Overview of the RecordNameSchemaManager
+=======================================
+
+The role of a schema manager
+----------------------------
+
+Your application needs to serialize data with the exact Avro schemas that it is developed and tested with, rather than the latest schema for a subject in the `Confluent Schema Registry`_.
+It's good practice, therefore, to package schemas with your application.
+
+At the same time, you cannot serialize messages without using the `Confluent Schema Registry`_: the registered ID of a schema is included in every Avro-encoded message (see the `Confluent Wire Format`_).
+
+The |RecordNameSchemaManager| helps you by automatically registering schema maintained inside your app with a `Confluent Schema Registry`_, and automatically associating schemas with their ID in a `Confluent Schema Registry`_ while serializing a message.
+
+The "record name" subject naming strategy
+-----------------------------------------
+
+The |RecordNameSchemaManager| specifically adheres to the ``RecordNameStrategy`` option for the Schema Registry's `subject name strategy <https://docs.confluent.io/current/schema-registry/serializer-formatter.html#subject-name-strategy>`__.
+Under this naming strategy, the name of a subject in the Schema Registry is the same as the fully-qualified name of the Avro schema.
+
+For example, the following Avro schema would be registered in a subject named ``myapp.a``:
+
+.. code-block:: json
+
+   {
+     "type": "record",
+     "name": "a",
+     "namespace": "myapp",
+     "fields": [
+       {"name": "field1", "type": "int"},
+       {"name": "field2", "type": "string"}
+     ]
+   }
+
+With the "record name" subject naming strategy, Schema Registry subjects are decoupled from Kafka topics: schemas for a given Schema Registry subject can appear in multiple Kafka topics, and a single Kafka topic can contain messages encoded with schemas from multiple subjects.
+
+By adhering to the "record name" subject naming strategy, the |RecordNameSchemaManager| lets you specify a schema through its fully-qualified name.
+Combined with |RecordNameSchemaManager|\ ’s control of schema versioning, this makes serialization applications convenient to write.
+
+.. note::
+
+   Other subject naming strategies exist, such as ``TopicNameStrategy`` and ``TopicRecordNameStrategy``.
+   In fact, ``TopicNameStrategy`` (which requires that subjects be named ``{topic}-key`` and ``{topic}-value``) is the default.
+   Although schema managers designed around these strategies aren't currently available, but they could be contributed.
+
+How to use the RecordNameSchemaManager
+======================================
+
+This section outlines the essential steps for integrating the |RecordNameSchemaManager| with your application.
+
+Step 1. Collect Avro schemas in a local directory
+-------------------------------------------------
+
+This workflow assumes that all the Avro schemas your application uses to serialize messages are maintained in the app's codebase.
+Gather all those schemas into one directory.
+
+This is a possible file layout:
+
+.. code-block:: text
+
+   .
+   └── src
+       └── myapp
+           ├── __init__.py
+           ├── app.py
+           └── avro_schemas/
+               ├── myapp.a.json
+               └── myapp.b.json
+
+Inside your application, store the path to the directory containing the Avro schemas:
+
+.. code-block:: python
+
+   from pathlib import Path
+
+   schema_root = Path(__file__).parent / "avro_schemas"
+
+Step 2. Initialize the RecordNameSchemaManager
+----------------------------------------------
+
+The |RecordNameSchemaManager| needs a Schema Registry API client:
+
+.. code-block:: python
+
+   from kafkit.registry.aiohttp import RegistryApi
+
+   async with aiohttp.ClientSession() as http_session:
+       registry_api = RegistryApi(
+           session=http_session, url="http://localhost:8081"
+       )
+       ...
+
+See `kafkit.registry.aiohttp.RegistryApi` for details.
+
+Then create the schema manager:
+
+.. code-block:: python
+
+   schema_manager = RecordNameSchemaManager(
+       root=schema_root, registry=registry_api,
+   )
+
+Step 3. Register schemas
+------------------------
+
+Next, register the locally-maintained schemas with the Schema Registry using the `~kafkit.registry.manager.RecordNameSchemaManager.register_schemas` method:
+
+.. code-block:: python
+
+   await manager.register_schemas(compatibility="FORWARD")
+
+The ``compatibility`` parameter allows you to set the compatibility settings for each schema's subject.
+If you do not wish to update the compatibility settings of subjects, or to use the registry's defaults, leave the ``compatibility`` parameter as `None`.
+
+.. note::
+
+   The ``FORWARD`` setting means that data serialized with the newer schema can be read by an application using an older version of that schema.
+   This setting is useful if schemas are managed by producers, and consumers are gradually updated to keep up.
+
+   See Confluent's documentation on `Schema Evolution and Compatibility`_ for information about this and other compatibility options.
+
+It's safe to use the `~kafkit.registry.manager.RecordNameSchemaManager.register_schemas` method with schemas that are already registered.
+The schema is automatically associated with its existing ID in the Schema Registry if it was previously registered.
+
+Step 4. Serialize messages using schema names
+---------------------------------------------
+
+Now the fun part — serializing messages into Avro:
+
+.. code-block:: python
+
+   data = {"field1": 42, "field2": "Hello world"}
+   message = await schema_manager.serialize(data=data, name="myapp.a")
+
+Serializing messages is straightforward because you don't need to maintain schemas or schema IDs in the code for producing messages.
+Instead, you only need to declare the name of the schema you are using to serialize data.
+
+The same `~kafkit.registry.manager.RecordNameSchemaManager.serialize` method can serialize both the key and value of a Kafka message.
+
+Now that your data is serialized, you can pass the ``message`` bytes object to `aiokafka.AIOKafkaProducer.send_and_wait`, or similar, method to produce a Kafka message.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,5 +106,5 @@ force_grid_wrap = 0
 use_parentheses = true
 line_length = 79
 known_first_party = "kafkit"
-known_third_party = ["fastavro", "pytest", "setuptools", "uritemplate"]
+known_third_party = ["aiohttp", "fastavro", "pytest", "setuptools", "uritemplate"]
 skip = ["docs/conf.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,17 @@ isolated_build = True
 description = Run pytest against {envname}.
 extras =
     dev
-commands=
+    aiohttp
+whitelist_externals =
+    docker-compose
+setenv =
+    KAFKA_BROKER_URL=localhost:9092
+    SCHEMA_REGISTRY_URL=http://localhost:8081
+commands =
+    docker-compose up -d
+    holdup -t 60 -T 5 -i 1 -n --insecure http://localhost:8081/subjects
     coverage run -m pytest {posargs}
+    docker-compose down
 
 [testenv:coverage-report]
 description = Compile coverage from each test run.

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ dev =
     lsst-sphinx-bootstrap-theme<0.3
     sphinx-prompt
     sphinx-automodapi==0.12
+    holdup
 
 [flake8]
 max-line-length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,3 +77,7 @@ strict_equality = True
 warn_redundant_casts = True
 warn_unreachable = True
 warn_unused_ignores = True
+
+[tool:pytest]
+markers =
+    docker: marks tests as requiring docker-compose (deselect with '-m "not docker"')

--- a/src/kafkit/httputils.py
+++ b/src/kafkit/httputils.py
@@ -4,13 +4,13 @@ This code is based on on the sans-io code of Gidgethub
 (https://github.com/brettcannon/gidgethub) and generalized for Kafkit.
 """
 
-__all__ = ["format_url", "parse_content_type"]
-
 import cgi
 import urllib.parse
 from typing import Mapping, Optional, Tuple
 
 import uritemplate
+
+__all__ = ["format_url", "parse_content_type"]
 
 
 def format_url(*, host: str, url: str, url_vars: Mapping[str, str]) -> str:

--- a/src/kafkit/registry/aiohttp.py
+++ b/src/kafkit/registry/aiohttp.py
@@ -10,11 +10,10 @@ from typing import TYPE_CHECKING, Mapping, Tuple
 
 from kafkit.registry import sansio
 
-__all__ = ["RegistryApi"]
-
-
 if TYPE_CHECKING:
     from aiohttp import ClientSession
+
+__all__ = ["RegistryApi"]
 
 
 class RegistryApi(sansio.RegistryApi):

--- a/src/kafkit/registry/manager.py
+++ b/src/kafkit/registry/manager.py
@@ -1,0 +1,311 @@
+"""Combined local and registry-based schema management."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
+
+from kafkit.registry.errors import RegistryBadRequestError
+from kafkit.registry.serializer import PolySerializer
+
+if TYPE_CHECKING:
+    from kafkit.registry.sansio import RegistryApi
+
+__all__ = ["RecordNameSchemaManager"]
+
+
+class RecordNameSchemaManager:
+    """A manager for schemas embedded in the application itself in conjunction
+    with a Confluent Schema Registry, for the case of a record name subject
+    name strategy.
+
+    Parameters
+    ----------
+    root : `pathlib.Path`
+        The root directory containing schemas. Schemas can be located within
+        this directory, or in a child directory. Schemas must have a
+        ``.json`` filename extension.
+    registry : `kafkit.registry.sansio.RegistryApi`
+        The Registry API client instance. For an application build with
+        ``aiohttp``, use the `kafkit.registry.aiohttp.RegistryApi` type.
+    suffix : `str`, optional
+        A suffix that is added to the schema name (and thus subject name), for
+        example ``_dev1``.
+
+        The suffix creates an alternate subjects in the Schema Registry so
+        schemas registered during testing and staging don't affect the
+        compatibility continuity of a production subject.
+
+        For production, it's best to not set a suffix.
+
+    Notes
+    -----
+    The ``RecordNameSchemaManager`` helps you manage Avro serialization in
+    your application. This class implements an opinionated workflow that
+    combines lower-level Kafkit components such as the
+    `~kafkit.registry.sansio.RegistryApi`, serializers and deserializers.
+    The key assumptions made by this manager are:
+
+    - Your application holds a local copy of the schemas it serializes and
+      deserializes data with. *This is useful so that your application can
+      be developed and tested independently of the Schema Registry.*
+
+    - Your application's schemas are located within a directory on the local
+      filesystem with ``*.json`` extensions.
+
+    - The Schema Registry subjects that your application uses have the same
+      compatibility setting.
+
+    - Subjects follow the **record name** naming strategy
+      (``RecordNameStrategy``). That is, the subject name is the
+      fully-qualified name of the Avro Schema.
+
+      *Note that this is different from the default naming strategy,*
+      ``TopicNameStrategy``, where subjects are named for the topic with
+      ``-key`` or ``-value`` suffixes.
+
+    For more information, see :doc:`/recordnameschemamanager-howto` in
+    the user guide.
+    """
+
+    def __init__(
+        self, *, root: Path, registry: RegistryApi, suffix: str = ""
+    ) -> None:
+        self._logger = logging.getLogger(__name__)
+        self._root = root
+        self._registry = registry
+        self._suffix = suffix
+
+        self._serializer = PolySerializer(registry=self._registry)
+        self.schemas: Dict[str, Any] = {}
+
+        self._load_schemas()
+
+    def _load_schemas(self) -> None:
+        """Load all schemas found in the root directory into the instance
+        storage.
+        """
+        schema_paths = self._root.rglob("*.json")
+        for schema_path in schema_paths:
+            schema = json.loads(schema_path.read_text())
+
+            if self._suffix:
+                schema["name"] = f'schema["name"]{self._suffix}'
+
+            fqn = self._get_fqn(schema)
+            self.schemas[fqn] = schema
+
+    @staticmethod
+    def _get_fqn(schema: Mapping[str, Any]) -> str:
+        """Get the fully-qualified name of an Avro schema.
+
+        Parameters
+        ----------
+        schema : `dict`
+            The Avro schema.
+
+        Returns
+        -------
+        str
+            The fully-qualified name.
+
+        Notes
+        -----
+        The decision sequence is:
+
+        - If the ``name`` field includes a period (``.``), the ``name`` field
+          is treated as a fully-qualified name.
+        - Otherwise, if the schema includes a ``namespace`` field, the
+          fully-qualified name is ``{{namespace}}.{{name}}``.
+        - Otherwise, the ``name`` is treated as the fully-qualified name.
+        """
+        if "." not in schema["name"] and "namespace" in schema:
+            fqn = ".".join((schema["namespace"], schema["name"]))
+        else:
+            fqn = schema["name"]
+        assert isinstance(fqn, str)
+        return fqn
+
+    async def register_schemas(
+        self, *, compatibility: Optional[str] = None
+    ) -> None:
+        """Register all local schemas with the Confluent Schema Registry.
+
+        Parameters
+        ----------
+        compatibility : `str`, optional
+            The compatibility setting to apply to all subjects. Allowed values:
+
+            - ``"BACKWARD"``
+            - ``"BACKWARD_TRANSITIVE"``
+            - ``"FORWARD"``
+            - ``"FORWARD_TRANSITIVE"``
+            - ``"FULL"``
+            - ``"FULL_TRANSITIVE"``
+            - ``"NONE"``
+            - `None`
+
+            If `None` (as opposed to ``"NONE"``), then no compatibility
+            setting is set during schema registration:
+
+            - If the subject doesn't already exist, it will inherit the
+              Schema Registry's global compatibility setting.
+            - If the subject already exists, it will continue to its
+              existing compatibility setting.
+
+            Learn more about schema compatibility in the `Confluent
+            documentation
+            <https://docs.confluent.io/current/schema-registry/avro.html>`__.
+        """
+        allowed = {
+            "BACKWARD",
+            "BACKWARD_TRANSITIVE",
+            "FORWARD",
+            "FORWARD_TRANSITIVE",
+            "FULL",
+            "FULL_TRANSITIVE",
+            "NONE",
+            None,
+        }
+        if compatibility not in allowed:
+            raise ValueError(
+                f"Compatibility setting {compatibility!r} is not in the "
+                f"allowed set: {allowed}"
+            )
+        for subject_name, schema in self.schemas.items():
+            await self._register_schema(
+                subject_name=subject_name,
+                schema=schema,
+                desired_compatibility=compatibility,
+            )
+
+    async def _register_schema(
+        self,
+        *,
+        subject_name: str,
+        schema: Dict[str, Any],
+        desired_compatibility: Optional[str],
+    ) -> int:
+        """Register a schema with the Schema Registry
+
+        Parameters
+        ----------
+        subject_name : `str`
+            The name of a subject in the Confluent Schema Registry, which
+            may already exist or not.
+        desired_compatibility : `str`
+            A subject compatibility setting. See docs for `register_schemas`
+            for possible values.
+
+        Returns
+        -------
+        int
+            Unique ID of the schema in the Schema in the Schema Registry.
+
+        Notes
+        -----
+        This method can be safely run multiple times with the same schema; in
+        each instance the same schema ID will be returned.
+        """
+        schema_id = await self._registry.register_schema(
+            schema, subject=subject_name
+        )
+
+        if desired_compatibility is not None:
+            await self._set_subject_compatibility(
+                subject_name=subject_name, compatibility=desired_compatibility
+            )
+        return schema_id
+
+    async def _set_subject_compatibility(
+        self, *, subject_name: str, compatibility: str
+    ) -> None:
+        """Set the compatibility for a Schema Registry subject.
+
+        Parameters
+        ----------
+        subject_name : `str`
+            The name of a subject that exists in the Confluent Schema Registry.
+        compatibility : `str`
+            A subject compatibility setting. See docs for `register_schemas`
+            for possible values.
+        """
+        try:
+            subject_config = await self._registry.get(
+                "/config{/subject}", url_vars={"subject": subject_name}
+            )
+        except RegistryBadRequestError:
+            self._logger.info(
+                "No existing configuration for this subject: %s", subject_name
+            )
+            # Create a mock config that forces a reset
+            subject_config = {"compatibilityLevel": None}
+
+        self._logger.debug(
+            "Current config subject=%s config=%s", subject_name, subject_config
+        )
+
+        if subject_config["compatibilityLevel"] != compatibility:
+            await self._registry.put(
+                "/config{/subject}",
+                url_vars={"subject": subject_name},
+                data={"compatibility": compatibility},
+            )
+            self._logger.info(
+                "Reset subject compatibility level. "
+                "subject=%s compatibility=%s",
+                subject_name,
+                compatibility,
+            )
+        else:
+            self._logger.debug(
+                "Existing subject compatibility level is good. "
+                "subject=%s compatibility=%s",
+                subject_name,
+                compatibility,
+            )
+
+    async def serialize(self, *, data: Any, name: str) -> bytes:
+        """Serialize data using the preregistered schema for a Schema Registry
+        subject.
+
+        Parameters
+        ----------
+        data : `dict`
+            An Avro-serializable object.
+        name : `str`
+            The name of the schema to serialize the ``data`` with. This is also
+            the name of the subject that the schema is associated with in the
+            Confluent Schema Registry, following the record name strategy
+
+            The specific schema that is used will be the one that was locally
+            registered by the RecordNameSchemaManager.
+
+        Returns
+        -------
+        `bytes`
+            The Avro-encoded message in the Confluent Wire Format (which
+            identifies the schema in the Schema Registry that was used to
+            encode the message).
+
+        Raises
+        ------
+        ValueError
+            Raised if there isn't a locally-available schema with that
+            record name / subject name.
+        """
+        if name not in self.schemas:
+            raise ValueError(
+                f"Schema named '{name}' not among the locally-registered "
+                f"schemas. Available schemas are: {self.schemas.keys()}"
+            )
+
+        schema = self.schemas[name]
+
+        encoded_message = await self._serializer.serialize(
+            data, schema=schema, subject=name
+        )
+
+        return encoded_message

--- a/src/kafkit/registry/manager.py
+++ b/src/kafkit/registry/manager.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
 
 from kafkit.registry.errors import RegistryBadRequestError
+from kafkit.registry.sansio import CompatibilityType
 from kafkit.registry.serializer import PolySerializer
 
 if TYPE_CHECKING:
@@ -159,21 +160,14 @@ class RecordNameSchemaManager:
             documentation
             <https://docs.confluent.io/current/schema-registry/avro.html>`__.
         """
-        allowed = {
-            "BACKWARD",
-            "BACKWARD_TRANSITIVE",
-            "FORWARD",
-            "FORWARD_TRANSITIVE",
-            "FULL",
-            "FULL_TRANSITIVE",
-            "NONE",
-            None,
-        }
-        if compatibility not in allowed:
-            raise ValueError(
-                f"Compatibility setting {compatibility!r} is not in the "
-                f"allowed set: {allowed}"
-            )
+        if isinstance(compatibility, str):
+            try:
+                CompatibilityType[compatibility]
+            except KeyError:
+                raise ValueError(
+                    f"Compatibility setting {compatibility!r} is not in the "
+                    f"allowed set: {[v.value for v in CompatibilityType]}"
+                )
         for subject_name, schema in self.schemas.items():
             await self._register_schema(
                 subject_name=subject_name,

--- a/src/kafkit/registry/sansio.py
+++ b/src/kafkit/registry/sansio.py
@@ -12,6 +12,7 @@ import abc
 import copy
 import json
 import logging
+from enum import Enum
 from typing import Any, Dict, Mapping, Optional, Tuple, Union, overload
 
 import fastavro
@@ -32,6 +33,7 @@ __all__ = [
     "MockRegistryApi",
     "SchemaCache",
     "SubjectCache",
+    "CompatibilityType",
 ]
 
 
@@ -898,3 +900,21 @@ class SubjectCache:
 
     def __contains__(self, key: Tuple[str, int]) -> bool:
         return key in self._subject_to_id
+
+
+class CompatibilityType(str, Enum):
+    """Compatibility settings available for the Confluent Schema Registry, as
+    an Enum.
+
+    To learn more about compatibility settings, see Confluent's documentation
+    on `Compatibility Types
+    <https://docs.confluent.io/current/schema-registry/avro.html#compatibility-types>`__.
+    """
+
+    BACKWARD = "BACKWARD"
+    BACKWARD_TRANSITIVE = "BACKWARD_TRANSITIVE"
+    FORWARD = "FORWARD"
+    FORWARD_TRANSITIVE = "FORWARD_TRANSITIVE"
+    FULL = "FULL"
+    FULL_TRANSITIVE = "FULL_TRANSITIVE"
+    NONE = "NONE"

--- a/src/kafkit/registry/serializer.py
+++ b/src/kafkit/registry/serializer.py
@@ -10,15 +10,14 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
 import fastavro
 
+if TYPE_CHECKING:
+    from kafit.registry.sansio import RegistryApi
+
 __all__ = [
     "Serializer",
     "PolySerializer",
     "Deserializer",
 ]
-
-
-if TYPE_CHECKING:
-    from kafit.registry.sansio import RegistryApi
 
 
 class Serializer:

--- a/src/kafkit/ssl.py
+++ b/src/kafkit/ssl.py
@@ -1,9 +1,9 @@
 """Support for connecting to brokers with SSL."""
 
-__all__ = ["create_ssl_context"]
-
 import ssl
 from pathlib import Path
+
+__all__ = ["create_ssl_context"]
 
 
 def create_ssl_context(

--- a/tests/data/record_name_schemas/kafkit.a.json
+++ b/tests/data/record_name_schemas/kafkit.a.json
@@ -1,0 +1,9 @@
+{
+  "type": "record",
+  "name": "a",
+  "namespace": "kafkit",
+  "fields": [
+    {"name": "field1", "type": "int"},
+    {"name": "field2", "type": "string"}
+  ]
+}

--- a/tests/data/record_name_schemas/kafkit.b.json
+++ b/tests/data/record_name_schemas/kafkit.b.json
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "name": "kafkit.b",
+  "fields": [
+    {"name": "fieldA", "type": "int"},
+    {"name": "fieldB", "type": "string"}
+  ]
+}

--- a/tests/registry_manager_test.py
+++ b/tests/registry_manager_test.py
@@ -1,0 +1,54 @@
+"""Tests for the kafkit.registry.manager module."""
+
+import os
+from pathlib import Path
+from typing import AsyncGenerator
+
+import pytest
+from aiohttp import ClientSession
+
+from kafkit.registry.aiohttp import RegistryApi
+from kafkit.registry.manager import RecordNameSchemaManager
+
+SCHEMA_ROOT = Path(__file__).parent / "data" / "record_name_schemas"
+"""the root path of schemas for testing the RecordNameSchemaManager."""
+
+
+@pytest.mark.asyncio
+@pytest.fixture
+async def http_session() -> AsyncGenerator[ClientSession, None]:
+    """Pytest fixture for an aiohttp ClientSession."""
+    async with ClientSession() as session:
+        yield session
+
+
+@pytest.mark.docker
+@pytest.mark.skipif(
+    os.getenv("SCHEMA_REGISTRY_URL") is None,
+    reason="SCHEMA_REGISTRY_URL env var must be configured",
+)
+@pytest.mark.asyncio
+async def test_recordnameschemamanager(http_session: ClientSession) -> None:
+    """Test the RecordNameSchemaManager using the docker-compose-based
+    Confluent Platform service deployment.
+
+    This test follows the expected usage for the manager.
+    """
+    registry_url = os.getenv("SCHEMA_REGISTRY_URL")
+    assert registry_url
+
+    registry = RegistryApi(url=registry_url, session=http_session)
+    manager = RecordNameSchemaManager(root=SCHEMA_ROOT, registry=registry)
+    await manager.register_schemas(compatibility="FORWARD")
+
+    topic_a_message = {"field1": 42, "field2": "hello"}
+    data_a = await manager.serialize(data=topic_a_message, name="kafkit.a")
+    assert isinstance(data_a, bytes)
+
+    topic_b_message = {"fieldA": 42, "fieldB": "hello"}
+    data_b = await manager.serialize(data=topic_b_message, name="kafkit.b")
+    assert isinstance(data_b, bytes)
+
+    # Sanity check that you can't serialize with the wrong schema!
+    with pytest.raises(ValueError):
+        await manager.serialize(data=topic_b_message, name="kafkit.a")


### PR DESCRIPTION
The `RecordNameSchemaManager` is a first shot at providing an easy-to-use API for serializing Avro messages using schemas that are maintained within an app's code base while also integrating with the Confluent Schema Registry. This manager is built around the "record name" subject naming strategy so that the message producer only needs to specify the name of the schema while serializing a message. Syncing with the Confluent Schema Registry is done largely behind the scenes.

This doc shows how it works: https://kafkit.lsst.io/v/DM-23797/recordnameschemamanager-howto.html

API docs: https://kafkit.lsst.io/v/DM-23797/api/kafkit.registry.manager.RecordNameSchemaManager.html#kafkit.registry.manager.RecordNameSchemaManager