### PR TITLE
DM-23797: Validate long_description and lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,12 @@ repos:
   - id: check-json
   - id: trailing-whitespace
 
+- repo: https://github.com/Lucas-C/pre-commit-hooks-markup
+  rev: v1.0.0
+  hooks:
+  - id: rst-linter
+    files: (README\.rst)|(CHANGELOG\.rst)
+
 - repo: https://github.com/asottile/seed-isort-config
   rev: v1.9.4
   hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,8 +38,6 @@ Several fixes:
 - The ``RegistryApi.put``, ``patch``, and ``delete`` methods weren't returning data. That's fixed now as well.
 - All of the RegistryApi's low-level HTTP methods have more thorough unit testing now to avoid these issues in the future.
 
-:jirab:`DM-17879`
-
 0.1.0 (2019-01-30)
 ==================
 
@@ -50,8 +48,6 @@ There are two client implementations.
 One is designed for aiohttp_ users (``kafkit.registry.aiohttp.RegistryClient``), and the other is for I/O-free unit testing (``kafkit.registry.sansio.MockRegistryApi``).
 The clients include schema caches so they can be used as both local stores of schemas, in addition to accessors for remote schemas.
 The release also includes a suite of Avro message serializers and deserializers that integrate with `Confluent Schema Registry`_ and the Confluent Wire Format (``kafkit.registry.serializer``).
-
-:jirab:`DM-17058`
 
 .. _aiohttp: https://aiohttp.readthedocs.io/en/stable/
 .. _Confluent Schema Registry: https://docs.confluent.io/current/schema-registry/docs/index.html


### PR DESCRIPTION
- Fixes rst formatting in the CHANGELOG (needed for PyPI release)
- Adds linting for the description sources via https://github.com/Lucas-C/pre-commit-hooks-markup