### PR TITLE
RegistryApi.register_schema always talks to Schema Registry when supplied a subject

### DIFF
--- a/src/kafkit/registry/sansio.py
+++ b/src/kafkit/registry/sansio.py
@@ -601,15 +601,31 @@ class MockRegistryApi(RegistryApi):
         self.response_headers = headers if headers else self.DEFAULT_HEADERS
         self.response_body = body
 
+        self.requests = []  # stores info about all requests made
+        self.counter = 0
+
     async def _request(
         self, method: str, url: str, headers: Mapping[str, str], body: bytes
     ) -> Any:
+        # reset if we've looped through all available responses
+        if isinstance(self.response_body, list) and self.counter == len(
+            self.response_body
+        ):
+            self.counter = 0
+        self.requests.append(
+            {"method": method, "url": url, "headers": headers, "body": body}
+        )
         self.method = method
         self.url = url
         self.headers = headers
         self.body = body
         response_headers = copy.deepcopy(self.response_headers)
-        return self.response_code, response_headers, self.response_body
+        if isinstance(self.response_body, list):
+            response_body = self.response_body[self.counter]
+        else:
+            response_body = self.response_body
+        self.counter += 1
+        return self.response_code, response_headers, response_body
 
 
 class SchemaCache:

--- a/tests/registry_serializer_test.py
+++ b/tests/registry_serializer_test.py
@@ -38,7 +38,6 @@ def test_unpacking_short_message() -> None:
 @pytest.mark.asyncio
 async def test_serializer() -> None:
     """Test the Serializer class."""
-    client = MockRegistryApi(body=json.dumps({"id": 1}).encode("utf-8"))
     schema1 = {
         "type": "record",
         "name": "schema1",
@@ -48,6 +47,19 @@ async def test_serializer() -> None:
             {"name": "b", "type": "string"},
         ],
     }
+    expected_body = [
+        json.dumps({"id": 1}).encode("utf-8"),
+        json.dumps(
+            {
+                "subject": "test-schemas.schema1",
+                "version": 1,
+                "id": 1,
+                "schema": json.dumps(schema1),
+            }
+        ).encode("utf-8"),
+    ]
+    client = MockRegistryApi(body=expected_body)
+
     serializer = await Serializer.register(registry=client, schema=schema1)
     assert serializer.id == 1
 
@@ -186,7 +198,17 @@ async def test_polyserializer_given_schema() -> None:
         ],
     }
 
-    body = json.dumps({"id": 1}).encode("utf-8")
+    body = [
+        json.dumps({"id": 1}).encode("utf-8"),
+        json.dumps(
+            {
+                "subject": "test-schemas.schema1",
+                "version": 1,
+                "id": 1,
+                "schema": json.dumps(schema),
+            }
+        ).encode("utf-8"),
+    ]
     client = MockRegistryApi(body=body)
 
     serializer = PolySerializer(registry=client)


### PR DESCRIPTION
Fixes #4 

Previously, when calling `RegistryApi.register_schema()`, it short-circuited and directly sent back the schema_id if the schema already existed in the schema_cache, regardless if we supplied a subject/schema combination that didn't previously exist.
This had the effect that the new subject never got created in the Schema Registry, and we didn't have the subject in the subject_cache in RegistryApi either.

This attempts to solve that problem