### PR TITLE
DM-35548: Add py.typed file (for 0.2.1 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.2.1 (2022-07-15)
+
+A `py.typed` file is now included to advertise typo annotations in Kafkit.
+
 ## 0.2.0 (2022-07-15)
 
 - Python versions 3.7 and earlier are no longer supported because Kafkit is adopting the `annotations` import from `__future__` and native support for `importlib.metadata`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ keywords = [
     "rubin",
     "lsst",
 ]
+# https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
@@ -22,6 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",
+    "Typing :: Typed",
 ]
 requires-python = ">=3.8"
 dependencies = [
@@ -67,6 +69,10 @@ build-backend = 'setuptools.build_meta'
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 where = ["src"]
 include = ["kafkit*"]
+
+[tool.setuptools.package-data]
+# https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data
+kafkit = ["py.typed"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
A `py.typed` file is now included to advertise typo annotations in Kafkit.
