### PR TITLE
DM-35548: Cleanup pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,6 @@ build-backend = 'setuptools.build_meta'
 where = ["src"]
 include = ["kafkit*"]
 
-[tool.setuptools.package-data]
-# https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data
-kafkit = ["py.typed"]
-
 [tool.setuptools_scm]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "uritemplate",
     "fastavro",
 ]
-# dynamic = ["version", "readme"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
@@ -42,7 +41,6 @@ dev = [
     "pytest-asyncio",
     "pre-commit",
     "mypy",
-    # holdup<3 # bug in holdup 3?
     # Documentation
     "sphinx",
     "documenteer",


### PR DESCRIPTION
- drop the explicit packaging-data section because setuptools-scm handles this for us.
- Clean up some left-over comments.