### PR TITLE
Remove `__named_schemas` hint in parsed schemas from fastavro

### DIFF
--- a/src/kafkit/registry/sansio.py
+++ b/src/kafkit/registry/sansio.py
@@ -394,10 +394,10 @@ class RegistryApi(metaclass=abc.ABCMeta):
         removing any fastavro hints and dumping to a string.
         """
         schema = dict(copy.deepcopy(schema))
-        try:
+        if "__fastavro_parsed" in schema:
             del schema["__fastavro_parsed"]
-        except KeyError:
-            pass
+        if "__named_schemas" in schema:
+            del schema["__named_schemas"]
         # sort keys for repeatable tests
         return json.dumps(schema, sort_keys=True)
 

--- a/tests/registry_sansio_test.py
+++ b/tests/registry_sansio_test.py
@@ -219,6 +219,7 @@ async def test_register_schema() -> None:
     assert "schema" in sent_json
     sent_schema = json.loads(sent_json["schema"])
     assert "__fastavro_parsed" not in sent_schema
+    assert "__named_schemas" not in sent_schema
     assert sent_schema["name"] == "test-schemas.schema1"
 
     # Check that the schema is in the cache and is parsed


### PR DESCRIPTION
First of all, thank you for this Python library. It is very useful for us :)

Kafkit currently removes the `__fastavro_parsed` hint from the parsed schema before submitting to the Schema Registry. This simple PR updates Kafkit to also remove the `__named_schemas` hint which is also added by fastavro. We have been using this fix for some years without any issues and decided to upstream it now that Kafkit got some life back.

The `__named_schemas` hint appeared in https://github.com/fastavro/fastavro/pull/451 (July 2020) to support nested schemas during parsing.

I also updated the unit test to validate that this new hint is also not submitted to the Schema Registry. All tests pass locally.
Note that I'm not testing if the new hint is present in the parsed schema, to preserve compatibility in the tests with older versions of fastavro that do not add this hint.

Finally, I decided to switch the current `try-except` approach to a more flexible `if-in-del` approach, again to preserve compatibility with older versions of fastavro that might not add the `__named_schemas` hint.