### PR TITLE
DM-38801: New PydanticSchemaManager

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
@@ -66,7 +66,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs,docs-linkcheck"
 
       # Only attempt documentation uploads for tagged releases and pull
@@ -98,5 +98,5 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ${{ secrets.PYPI_SQRE_ADMIN }}
-          python-version: "3.10"
+          python-version: "3.11"
           upload: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Build docs in tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           tox-envs: "docs,docs-linkcheck"
           use-cache: false
 
@@ -55,5 +55,5 @@ jobs:
         uses: lsst-sqre/build-and-publish-to-pypi@v1
         with:
           pypi-token: ""
-          python-version: "3.10"
+          python-version: "3.11"
           upload: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+
+### New features
+
+- New `PydanticSchemaManager` enables you to use [Pydantic](https://pydantic-docs.helpmanual.io/) models as Avro schemas. Like the `RecordNameSchemaManager`, this new manager handles schema registration for you. To serialize a message, you simply supply a Pydantic object. The manager will also deserialize messages into Pydantic objects if the message's schema corresponds to a managed Pydantic model. Overall this feature provides end-to-end type checking of messages from development to production.
+
 ## 0.3.0 (2023-02-23)
 
 New features:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:
 
 .PHONY: init
 init:
-	pip install -e ".[aiohttp,httpx,dev]"
+	pip install -e ".[aiohttp,httpx,pydantic,dev]"
 	pip install -U tox pre-commit
 	pre-commit install
 	rm -rf .tox

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,6 @@ help:
 .PHONY: init
 init:
 	pip install -e ".[aiohttp,httpx,dev]"
-	pip install tox pre-commit
+	pip install -U tox pre-commit
 	pre-commit install
 	rm -rf .tox

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -43,9 +43,6 @@ Pre-commit hooks
 The pre-commit hooks, which are automatically installed by running the :command:`make init` command on :ref:`set up <dev-environment>`, ensure that files are valid and properly formatted.
 Some pre-commit hooks automatically reformat code:
 
-``seed-isort-config``
-    Adds configuration for isort to the :file:`pyproject.toml` file.
-
 ``isort``
     Automatically sorts imports in Python modules.
 
@@ -73,13 +70,13 @@ You can also run tox_, which tests the library the same way that the CI workflow
 
 .. code-block:: sh
 
-   tox
+   tox run
 
 To see a listing of test environments, run:
 
 .. code-block:: sh
 
-   tox -av
+   tox list
 
 .. _dev-build-docs:
 
@@ -92,7 +89,7 @@ Documentation is built with Sphinx_:
 
 .. code-block:: sh
 
-   tox -e docs
+   tox run -e docs
 
 The build documentation is located in the :file:`docs/_build/html` directory.
 
@@ -101,22 +98,20 @@ The build documentation is located in the :file:`docs/_build/html` directory.
 Updating the change log
 =======================
 
-Each pull request should update the change log (:file:`CHANGELOG.rst`).
+Each pull request should update the change log (:file:`CHANGELOG.md`).
 Add a description of new features and fixes as list items under a section at the top of the change log called "Unreleased:"
 
-.. code-block:: rst
+.. code-block:: md
 
-   Unreleased
-   ----------
+   ## Unreleased
 
    - Description of the feature or fix.
 
-If the next version is known (because Kafkit's master branch is being prepared for a new major or minor version), the section may contain that version information:
+If the next version is known (because Kafkit's main branch is being prepared for a new major or minor version), the section may contain that version information:
 
-.. code-block:: rst
+.. code-block:: md
 
-   X.Y.0 (unreleased)
-   ------------------
+   ## X.Y.0 (unreleased)
 
    - Description of the feature or fix.
 
@@ -124,8 +119,7 @@ If the exact version and release date is known (:doc:`because a release is being
 
 .. code-block:: rst
 
-   X.Y.0 (YYYY-MM-DD)
-   ------------------
+   ## X.Y.0 (YYYY-MM-DD)
 
    - Description of the feature or fix.
 

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -10,15 +10,15 @@ When a semantic version tag is pushed to GitHub, `Kafkit is released to PyPI`_ w
 Similarly, documentation is built and pushed for each version (see https://kafkit.lsst.io/v).
 
 .. _`Kafkit is released to PyPI`: https://pypi.org/project/kafkit/
-.. _`ci.yaml`: https://github.com/lsst-sqre/kafkit/blob/master/.github/workflows/ci.yaml
+.. _`ci.yaml`: https://github.com/lsst-sqre/kafkit/blob/main/.github/workflows/ci.yaml
 
 .. _regular-release:
 
 Regular releases
 ================
 
-Regular releases happen from the ``master`` branch after changes have been merged.
-From the ``master`` branch you can release a new major version (``X.0.0``), a new minor version of the current major version (``X.Y.0``), or a new patch of the current major-minor version (``X.Y.Z``).
+Regular releases happen from the ``main`` branch after changes have been merged.
+From the ``main`` branch you can release a new major version (``X.0.0``), a new minor version of the current major version (``X.Y.0``), or a new patch of the current major-minor version (``X.Y.Z``).
 See :ref:`backport-release` to patch an earlier major-minor version.
 
 Release tags are semantic version identifiers following the :pep:`440` specification.
@@ -27,7 +27,7 @@ Release tags are semantic version identifiers following the :pep:`440` specifica
 -------------------------------
 
 Each PR should include updates to the change log.
-If the change log or documentation needs additional updates, now is the time to make those changes through the regular branch-and-PR development method against the ``master`` branch.
+If the change log or documentation needs additional updates, now is the time to make those changes through the regular branch-and-PR development method against the ``main`` branch.
 
 In particular, replace the "Unreleased" section headline with the semantic version and date.
 See :ref:`dev-change-log` in the *Developer guide* for details.
@@ -35,7 +35,7 @@ See :ref:`dev-change-log` in the *Developer guide* for details.
 2. Tag the release
 ------------------
 
-At the HEAD of the ``master`` branch, create and push a tag with the semantic version:
+At the HEAD of the ``main`` branch, create and push a tag with the semantic version:
 
 .. code-block:: sh
 
@@ -54,7 +54,7 @@ The `ci.yaml`_ GitHub Actions workflow uploads the new release to PyPI and docum
 Backport releases
 =================
 
-The regular release procedure works from the main line of development on the ``master`` Git branch.
+The regular release procedure works from the main line of development on the ``main`` Git branch.
 To create a release that patches an earlier major or minor version, you need to release from a **release branch.**
 
 Creating a release branch
@@ -72,12 +72,12 @@ If the release branch doesn't already exist, check out the latest patch for that
 Developing on a release branch
 ------------------------------
 
-Once a release branch exists, it becomes the "master" branch for patches of that major-minor version.
+Once a release branch exists, it becomes the "main" branch for patches of that major-minor version.
 Pull requests should be based on, and merged into, the release branch.
 
-If the development on the release branch is a backport of commits on the ``master`` branch, use ``git cherry-pick`` to copy those commits into a new pull request against the release branch.
+If the development on the release branch is a backport of commits on the ``main`` branch, use ``git cherry-pick`` to copy those commits into a new pull request against the release branch.
 
 Releasing from a release branch
 -------------------------------
 
-Releases from a release branch are equivalent to :ref:`regular releases <regular-release>`, except that the release branch takes the role of the ``master`` branch.
+Releases from a release branch are equivalent to :ref:`regular releases <regular-release>`, except that the release branch takes the role of the ``main`` branch.

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -16,6 +16,14 @@ nitpick_ignore = [
         "py:class",
         "httpx.AsyncClient",
     ],
+    [
+        "py:class",
+        "AvroBaseModel",
+    ],
+    [
+        "py:class",
+        "dataclasses_avroschema.avrodantic.AvroBaseModel",
+    ],
 ]
 
 [sphinx.intersphinx.projects]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,13 @@ classifiers = [
     "Typing :: Typed",
 ]
 requires-python = ">=3.8"
-dependencies = ["uritemplate", "fastavro"]
+dependencies = ["fastavro", "uritemplate"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 aiohttp = ["aiohttp"]
 httpx = ["httpx"]
+pydantic = ["dataclasses-avroschema[pydantic]"]
 dev = [
     # Testing
     "coverage[toml]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: POSIX",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-"""Legacy setuptools build front-end (pre PEP 517)."""
-
-from setuptools import setup
-
-setup(use_scm_version=True)

--- a/src/kafkit/registry/__init__.py
+++ b/src/kafkit/registry/__init__.py
@@ -8,6 +8,7 @@ from kafkit.registry.errors import (
     RegistryError,
     RegistryHttpError,
     RegistryRedirectionError,
+    UnmanagedSchemaError,
 )
 from kafkit.registry.serializer import (
     Deserializer,
@@ -26,4 +27,5 @@ __all__ = [
     "RegistryError",
     "RegistryHttpError",
     "RegistryRedirectionError",
+    "UnmanagedSchemaError",
 ]

--- a/src/kafkit/registry/__init__.py
+++ b/src/kafkit/registry/__init__.py
@@ -9,10 +9,16 @@ from kafkit.registry.errors import (
     RegistryHttpError,
     RegistryRedirectionError,
 )
-from kafkit.registry.serializer import Deserializer, PolySerializer, Serializer
+from kafkit.registry.serializer import (
+    Deserializer,
+    MessageInfo,
+    PolySerializer,
+    Serializer,
+)
 
 __all__ = [
     "Deserializer",
+    "MessageInfo",
     "Serializer",
     "PolySerializer",
     "RegistryBadRequestError",

--- a/src/kafkit/registry/errors.py
+++ b/src/kafkit/registry/errors.py
@@ -6,6 +6,7 @@ __all__ = [
     "RegistryRedirectionError",
     "RegistryBadRequestError",
     "RegistryBrokenError",
+    "UnmanagedSchemaError",
 ]
 
 from typing import Any, Optional
@@ -61,3 +62,9 @@ class RegistryBadRequestError(RegistryHttpError):
 
 class RegistryBrokenError(RegistryHttpError):
     """An excpetion if the server is down (5XX errors)."""
+
+
+class UnmanagedSchemaError(Exception):
+    """An exception for when a schema is not managed by the Registry, and
+    therefore cannot be deserialized into a native Python object.
+    """

--- a/src/kafkit/registry/manager/__init__.py
+++ b/src/kafkit/registry/manager/__init__.py
@@ -2,6 +2,7 @@
 serialization and deserialization of messages.
 """
 
+from ._pydantic import PydanticSchemaManager
 from ._recordname import RecordNameSchemaManager
 
-__all__ = ["RecordNameSchemaManager"]
+__all__ = ["RecordNameSchemaManager", "PydanticSchemaManager"]

--- a/src/kafkit/registry/manager/__init__.py
+++ b/src/kafkit/registry/manager/__init__.py
@@ -1,0 +1,7 @@
+"""Schema managers register schemas with the registry and enable conventient
+serialization and deserialization of messages.
+"""
+
+from ._recordname import RecordNameSchemaManager
+
+__all__ = ["RecordNameSchemaManager"]

--- a/src/kafkit/registry/manager/_pydantic.py
+++ b/src/kafkit/registry/manager/_pydantic.py
@@ -1,0 +1,147 @@
+"""Schema management that uses Pydantic models as the Python representation
+of schemas.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Type
+
+from ..serializer import PolySerializer
+from ..utils import get_avro_fqn
+
+if TYPE_CHECKING:
+    from dataclasses_avroschema.avrodantic import AvroBaseModel
+
+    from kafkit.registry.sansio import RegistryApi
+
+__all__ = ["PydanticSchemaManager"]
+
+
+@dataclass
+class CachedSchema:
+    """A cached schema and model."""
+
+    schema: dict[str, Any]
+    """The Avro schema derived from the model."""
+
+    model: Type[AvroBaseModel]
+    """The Pydantic model."""
+
+
+class PydanticSchemaManager:
+    """A manager for schemas that are represented as Pydantic models in Python,
+    and translated into Avro for the Confluent Schema Registry.
+
+    Parameters
+    ----------
+    registry
+        The Registry API client instance. For an application build with
+        ``aiohttp``, use the `kafkit.registry.aiohttp.RegistryApi` type.
+    suffix
+        A suffix that is added to the schema name (and thus subject name), for
+        example ``_dev1``.
+
+        The suffix creates alternate subjects in the Schema Registry so
+        schemas registered during testing and staging don't affect the
+        compatibility continuity of a production subject.
+
+        For production, it's best to not set a suffix.
+    """
+
+    def __init__(self, *, registry: RegistryApi, suffix: str = "") -> None:
+        self._registry = registry
+        self._suffix = suffix
+
+        self._logger = logging.getLogger(__name__)
+
+        self._serializer = PolySerializer(registry=self._registry)
+
+        # A mapping of fully-qualified schema names to models.
+        self._models: dict[str, CachedSchema] = {}
+
+    async def register_models(
+        self,
+        models: Iterable[Type[AvroBaseModel]],
+        compatibility: Optional[str] = None,
+    ) -> None:
+        """Register the models with the registry.
+
+        Parameters
+        ----------
+        models
+            The models to register.
+        """
+        for model in models:
+            await self.register_model(model, compatibility=compatibility)
+
+    async def register_model(
+        self, model: Type[AvroBaseModel], compatibility: Optional[str] = None
+    ) -> None:
+        """Register the model with the registry.
+
+        Parameters
+        ----------
+        model
+            The model to register.
+        """
+        cached_schema = self._cache_model(model)
+        schema_fqn = get_avro_fqn(cached_schema.schema)
+
+        await self._registry.register_schema(
+            schema=cached_schema.schema,
+            subject=schema_fqn,
+            compatibility=compatibility,
+        )
+
+    async def serialize(self, data: AvroBaseModel) -> bytes:
+        """Serialize the data.
+
+        Parameters
+        ----------
+        data
+            The data to serialize.
+        """
+        schema_fqn = self._get_model_fqn(data)
+
+        if schema_fqn in self._models:
+            avro_schema = self._models[schema_fqn].schema
+        else:
+            cached_model = self._cache_model(data)
+            avro_schema = cached_model.schema
+
+        return await self._serializer.serialize(
+            data, schema=avro_schema, subject=schema_fqn
+        )
+
+    def _cache_model(
+        self, model: AvroBaseModel | Type[AvroBaseModel]
+    ) -> CachedSchema:
+        schema_fqn = self._get_model_fqn(model)
+        avro_schema = model.avro_schema_to_python()
+
+        self._models[schema_fqn] = CachedSchema(avro_schema, model)
+
+        return self._models[schema_fqn]
+
+    def _get_model_fqn(
+        self, model: AvroBaseModel | Type[AvroBaseModel]
+    ) -> str:
+        try:
+            name = model.Meta.schema_name
+        except AttributeError:
+            name = model.__class__.__name__
+
+        try:
+            namespace = model.Meta.namespace
+        except AttributeError:
+            namespace = None
+
+        if namespace:
+            name = f"{namespace}.{name}"
+
+        if self._suffix:
+            name += self._suffix
+
+        return name

--- a/src/kafkit/registry/manager/_recordname.py
+++ b/src/kafkit/registry/manager/_recordname.py
@@ -9,8 +9,6 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
 
-from kafkit.registry.errors import RegistryBadRequestError
-from kafkit.registry.sansio import CompatibilityType
 from kafkit.registry.serializer import PolySerializer
 
 if TYPE_CHECKING:
@@ -76,10 +74,11 @@ class RecordNameSchemaManager:
     def __init__(
         self, *, root: Path, registry: RegistryApi, suffix: str = ""
     ) -> None:
-        self._logger = logging.getLogger(__name__)
-        self._root = root
         self._registry = registry
+        self._root = root
         self._suffix = suffix
+
+        self._logger = logging.getLogger(__name__)
 
         self._serializer = PolySerializer(registry=self._registry)
         self.schemas: Dict[str, Any] = {}
@@ -162,105 +161,11 @@ class RecordNameSchemaManager:
             documentation
             <https://docs.confluent.io/current/schema-registry/avro.html>`__.
         """
-        if isinstance(compatibility, str):
-            try:
-                CompatibilityType[compatibility]
-            except KeyError:
-                raise ValueError(
-                    f"Compatibility setting {compatibility!r} is not in the "
-                    f"allowed set: {[v.value for v in CompatibilityType]}"
-                )
         for subject_name, schema in self.schemas.items():
-            await self._register_schema(
-                subject_name=subject_name,
+            await self._registry.register_schema(
                 schema=schema,
-                desired_compatibility=compatibility,
-            )
-
-    async def _register_schema(
-        self,
-        *,
-        subject_name: str,
-        schema: Dict[str, Any],
-        desired_compatibility: Optional[str],
-    ) -> int:
-        """Register a schema with the Schema Registry
-
-        Parameters
-        ----------
-        subject_name : `str`
-            The name of a subject in the Confluent Schema Registry, which
-            may already exist or not.
-        desired_compatibility : `str`
-            A subject compatibility setting. See docs for `register_schemas`
-            for possible values.
-
-        Returns
-        -------
-        int
-            Unique ID of the schema in the Schema in the Schema Registry.
-
-        Notes
-        -----
-        This method can be safely run multiple times with the same schema; in
-        each instance the same schema ID will be returned.
-        """
-        schema_id = await self._registry.register_schema(
-            schema, subject=subject_name
-        )
-
-        if desired_compatibility is not None:
-            await self._set_subject_compatibility(
-                subject_name=subject_name, compatibility=desired_compatibility
-            )
-        return schema_id
-
-    async def _set_subject_compatibility(
-        self, *, subject_name: str, compatibility: str
-    ) -> None:
-        """Set the compatibility for a Schema Registry subject.
-
-        Parameters
-        ----------
-        subject_name : `str`
-            The name of a subject that exists in the Confluent Schema Registry.
-        compatibility : `str`
-            A subject compatibility setting. See docs for `register_schemas`
-            for possible values.
-        """
-        try:
-            subject_config = await self._registry.get(
-                "/config{/subject}", url_vars={"subject": subject_name}
-            )
-        except RegistryBadRequestError:
-            self._logger.info(
-                "No existing configuration for this subject: %s", subject_name
-            )
-            # Create a mock config that forces a reset
-            subject_config = {"compatibilityLevel": None}
-
-        self._logger.debug(
-            "Current config subject=%s config=%s", subject_name, subject_config
-        )
-
-        if subject_config["compatibilityLevel"] != compatibility:
-            await self._registry.put(
-                "/config{/subject}",
-                url_vars={"subject": subject_name},
-                data={"compatibility": compatibility},
-            )
-            self._logger.info(
-                "Reset subject compatibility level. "
-                "subject=%s compatibility=%s",
-                subject_name,
-                compatibility,
-            )
-        else:
-            self._logger.debug(
-                "Existing subject compatibility level is good. "
-                "subject=%s compatibility=%s",
-                subject_name,
-                compatibility,
+                subject=subject_name,
+                compatibility=compatibility,
             )
 
     async def serialize(self, *, data: Any, name: str) -> bytes:

--- a/src/kafkit/registry/manager/_recordname.py
+++ b/src/kafkit/registry/manager/_recordname.py
@@ -1,4 +1,6 @@
-"""Combined local and registry-based schema management."""
+"""Manage schemas as avro files based on the record name subject name
+strategy.
+"""
 
 from __future__ import annotations
 

--- a/src/kafkit/registry/manager/_recordname.py
+++ b/src/kafkit/registry/manager/_recordname.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from kafkit.registry.serializer import PolySerializer
+
+from ..utils import get_avro_fqn
 
 if TYPE_CHECKING:
     from kafkit.registry.sansio import RegistryApi
@@ -96,39 +98,8 @@ class RecordNameSchemaManager:
             if self._suffix:
                 schema["name"] = f'{schema["name"]}{self._suffix}'
 
-            fqn = self._get_fqn(schema)
+            fqn = get_avro_fqn(schema)
             self.schemas[fqn] = schema
-
-    @staticmethod
-    def _get_fqn(schema: Mapping[str, Any]) -> str:
-        """Get the fully-qualified name of an Avro schema.
-
-        Parameters
-        ----------
-        schema : `dict`
-            The Avro schema.
-
-        Returns
-        -------
-        str
-            The fully-qualified name.
-
-        Notes
-        -----
-        The decision sequence is:
-
-        - If the ``name`` field includes a period (``.``), the ``name`` field
-          is treated as a fully-qualified name.
-        - Otherwise, if the schema includes a ``namespace`` field, the
-          fully-qualified name is ``{{namespace}}.{{name}}``.
-        - Otherwise, the ``name`` is treated as the fully-qualified name.
-        """
-        if "." not in schema["name"] and "namespace" in schema:
-            fqn = ".".join((schema["namespace"], schema["name"]))
-        else:
-            fqn = schema["name"]
-        assert isinstance(fqn, str)
-        return fqn
 
     async def register_schemas(
         self, *, compatibility: Optional[str] = None

--- a/src/kafkit/registry/utils.py
+++ b/src/kafkit/registry/utils.py
@@ -1,0 +1,38 @@
+"""Utilities related to Avro schemas and the Confluent Schema Registry."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+__all__ = ["get_avro_fqn"]
+
+
+def get_avro_fqn(schema: Mapping[str, Any]) -> str:
+    """Get the fully-qualified name of an Avro schema.
+
+    Parameters
+    ----------
+    schema
+        The Avro schema.
+
+    Returns
+    -------
+    str
+        The fully-qualified name.
+
+    Notes
+    -----
+    The decision sequence is:
+
+    - If the ``name`` field includes a period (``.``), the ``name`` field
+        is treated as a fully-qualified name.
+    - Otherwise, if the schema includes a ``namespace`` field, the
+        fully-qualified name is ``{{namespace}}.{{name}}``.
+    - Otherwise, the ``name`` is treated as the fully-qualified name.
+    """
+    if "." not in schema["name"] and "namespace" in schema:
+        fqn = ".".join((schema["namespace"], schema["name"]))
+    else:
+        fqn = schema["name"]
+    assert isinstance(fqn, str)
+    return fqn

--- a/tests/pydantic_schema_manager_test.py
+++ b/tests/pydantic_schema_manager_test.py
@@ -1,0 +1,138 @@
+"""Tests for the PydanticSchemaManager class."""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from typing import Optional
+
+import pytest
+from dataclasses_avroschema.avrodantic import AvroBaseModel
+from httpx import AsyncClient
+from pydantic import Field
+
+from kafkit.registry.httpx import RegistryApi
+from kafkit.registry.manager import PydanticSchemaManager
+
+
+class SlackMessageType(str, Enum):
+    """The type of Slack message."""
+
+    app_mention = "app_mention"
+    message = "message"
+
+
+class SlackChannelType(str, Enum):
+    """The type of Slack channel."""
+
+    channel = "channel"  # public channel
+    group = "group"  # private channel
+    im = "im"  # direct message
+    mpim = "mpim"  # multi-persion direct message
+
+
+class SquarebotMessage(AvroBaseModel):
+    """Model for a Slack message produced by Squarebot."""
+
+    type: SlackMessageType = Field(description="The Slack message type.")
+
+    channel: str = Field(
+        description=(
+            "ID of the channel where the message was sent "
+            "(e.g., C0LAN2Q65)."
+        )
+    )
+
+    channel_type: SlackChannelType = Field(
+        description="The type of channel (public, direct im, etc..)"
+    )
+
+    user: Optional[str] = Field(
+        description="The ID of the user that sent the message (eg U061F7AUR)."
+    )
+
+    text: str = Field(description="Content of the message.")
+
+    ts: str = Field(description="Timestamp of the message.")
+
+    event_ts: str = Field(description="When the event was dispatched.")
+
+    class Meta:
+        """Metadata for the model."""
+
+        namespace = "squarebot"
+        schema_name = "message"
+
+
+@pytest.mark.docker
+@pytest.mark.skipif(
+    os.getenv("SCHEMA_REGISTRY_URL") is None,
+    reason="SCHEMA_REGISTRY_URL env var must be configured",
+)
+@pytest.mark.asyncio
+async def test_pydantic_schema_manager() -> None:
+    """Test that the Pydantic Schema Manager can register a schema based on
+    a Pydantic model, and serialize/deserialize Pydantic models.
+    """
+    registry_url = os.getenv("SCHEMA_REGISTRY_URL")
+    assert registry_url
+
+    async with AsyncClient() as http_client:
+        registry = RegistryApi(http_client=http_client, url=registry_url)
+        manager = PydanticSchemaManager(registry=registry)
+
+        # Register the schema
+        await manager.register_model(SquarebotMessage, compatibility="FORWARD")
+
+        # Check the cache
+        assert manager._models.get("squarebot.message") is not None
+        assert manager._models["squarebot.message"].model == SquarebotMessage
+
+        input_message = SquarebotMessage.fake()
+
+        # Serialize the message
+        serialized_data = await manager.serialize(input_message)
+
+        # Deserialize the message
+        output_message = await manager.deserialize(serialized_data)
+
+        # Check that the deserialized message is the same as the input
+        assert isinstance(output_message, SquarebotMessage)
+        assert output_message == input_message
+
+
+@pytest.mark.docker
+@pytest.mark.skipif(
+    os.getenv("SCHEMA_REGISTRY_URL") is None,
+    reason="SCHEMA_REGISTRY_URL env var must be configured",
+)
+@pytest.mark.asyncio
+async def test_pydantic_schema_manager_suffixed() -> None:
+    """Test that the Pydantic Schema Manager can set a subject name suffix."""
+    registry_url = os.getenv("SCHEMA_REGISTRY_URL")
+    assert registry_url
+
+    async with AsyncClient() as http_client:
+        registry = RegistryApi(http_client=http_client, url=registry_url)
+        manager = PydanticSchemaManager(registry=registry, suffix="_v1")
+
+        # Register the schema
+        await manager.register_model(SquarebotMessage, compatibility="FORWARD")
+
+        # Check the cache
+        assert manager._models.get("squarebot.message_v1") is not None
+        assert (
+            manager._models["squarebot.message_v1"].model == SquarebotMessage
+        )
+
+        input_message = SquarebotMessage.fake()
+
+        # Serialize the message
+        serialized_data = await manager.serialize(input_message)
+
+        # Deserialize the message
+        output_message = await manager.deserialize(serialized_data)
+
+        # Check that the deserialized message is the same as the input
+        assert isinstance(output_message, SquarebotMessage)
+        assert output_message == input_message

--- a/tests/registry_serializer_test.py
+++ b/tests/registry_serializer_test.py
@@ -113,14 +113,15 @@ async def test_deserializer() -> None:
     deserializer = Deserializer(registry=client)
 
     response_1 = await deserializer.deserialize(data_1)
+    # Test attribute and key-based access to message info
     assert response_1["id"] == schema1_id
     assert response_1["message"] == message_1
-    assert "schema" not in response_1
+    assert response_1.id == schema1_id
+    assert response_1.message == message_1
 
-    response_2 = await deserializer.deserialize(data_2, include_schema=True)
+    response_2 = await deserializer.deserialize(data_2)
     assert response_2["id"] == schema2_id
     assert response_2["message"] == message_2
-    assert "schema" in response_2
     assert response_2["schema"]["name"] == "test-schemas.schema2"
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 [testenv:typing]
 description = Run mypy.
 commands =
-    mypy src/kafkit tests setup.py
+    mypy src/kafkit tests
 
 [testenv:lint]
 description = Lint codebase by running pre-commit (Black, isort, Flake8).

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ extras =
     dev
     aiohttp
     httpx
+    pydantic
 allowlist_externals =
     docker-compose
 setenv =


### PR DESCRIPTION
This PR add new `PydanticSchemaManager` that enables you to use [Pydantic](https://pydantic-docs.helpmanual.io/) models as Avro schemas. Like the `RecordNameSchemaManager`, this new manager handles schema registration for you. To serialize a message, you simply supply a Pydantic object. The manager will also deserialize messages into Pydantic objects if the message's schema corresponds to a managed Pydantic model. Overall this feature provides end-to-end type checking of messages from development to production.