### PR TITLE
DM-39648: Add kafkit.settings module

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+changelog.d/_template.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change log
 
+<!-- scriv-insert-here -->
+
 ## Unreleased
 
 ### New features

--- a/changelog.d/20230613_123447_jsick_DM_39648.md
+++ b/changelog.d/20230613_123447_jsick_DM_39648.md
@@ -1,0 +1,15 @@
+### Backwards-incompatible changes
+
+-
+
+### New features
+
+- Added a new `kafkit.settings` module that provides a `KafkaConnectionSettings` class. this class uses Pydantic's BaseSettings to gather environment variables. Applications can use this settings to consistently configure their Kafka clients. `KafkaConnectionSettings` also provides a ready-to-use `SSLContext` for connecting to Kafka brokers over TLS.
+
+### Bug fixes
+
+-
+
+### Other changes
+
+- We're now using [scriv](https://scriv.readthedocs.io) to manage the changelog.

--- a/changelog.d/_template.md
+++ b/changelog.d/_template.md
@@ -1,0 +1,7 @@
+<!-- Delete the sections that don't apply -->
+{%- for cat in config.categories %}
+
+### {{ cat }}
+
+-
+{%- endfor %}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,5 +17,8 @@ Kafkit API reference
 .. automodapi:: kafkit.registry.sansio
    :no-inheritance-diagram:
 
+.. automodapi:: kafkit.settings
+   :no-inheritance-diagram:
+
 .. automodapi:: kafkit.ssl
    :no-inheritance-diagram:

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -24,6 +24,18 @@ nitpick_ignore = [
         "py:class",
         "dataclasses_avroschema.avrodantic.AvroBaseModel",
     ],
+    [
+        "py:class",
+        "pydantic.env_settings.BaseSettings",
+    ],
+    [
+        "py:class",
+        "pydantic.main.BaseModel",
+    ],
+    [
+        "py:class",
+        "pydantic.utils.Representation",
+    ]
 ]
 
 [sphinx.intersphinx.projects]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 aiohttp = ["aiohttp"]
 httpx = ["httpx"]
-pydantic = ["dataclasses-avroschema[pydantic]"]
+pydantic = ["pydantic", "dataclasses-avroschema[pydantic]"]
 dev = [
     # Testing
     "coverage[toml]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,3 +140,16 @@ strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
+
+[tool.scriv]
+categories = [
+    "Backwards-incompatible changes",
+    "New features",
+    "Bug fixes",
+    "Other changes",
+]
+entry_title_template = "{{ version }} ({{ date.strftime('%Y-%m-%d') }})"
+format = "md"
+md_header_level = "2"
+new_fragment_template = "file:changelog.d/_template.md"
+skip_fragments = "_template.md"

--- a/src/kafkit/settings.py
+++ b/src/kafkit/settings.py
@@ -1,0 +1,204 @@
+"""Pydantic BaseSettings for configuring Kafka clients."""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from ssl import SSLContext
+
+from pydantic import BaseSettings, DirectoryPath, Field, FilePath, SecretStr
+
+from .ssl import create_ssl_context
+
+__all__ = [
+    "KafkaConnectionSettings",
+    "KafkaSecurityProtocol",
+    "KafkaSaslMechanism",
+]
+
+
+class KafkaSecurityProtocol(str, Enum):
+    """Kafka security protocols understood by aiokafka."""
+
+    PLAINTEXT = "PLAINTEXT"
+    """Plain-text connection."""
+
+    SSL = "SSL"
+    """TLS-encrypted connection."""
+
+
+class KafkaSaslMechanism(str, Enum):
+    """Kafka SASL mechanisms understood by aiokafka."""
+
+    PLAIN = "PLAIN"
+    """Plain-text SASL mechanism."""
+
+    SCRAM_SHA_256 = "SCRAM-SHA-256"
+    """SCRAM-SHA-256 SASL mechanism."""
+
+    SCRAM_SHA_512 = "SCRAM-SHA-512"
+    """SCRAM-SHA-512 SASL mechanism."""
+
+
+class KafkaConnectionSettings(BaseSettings):
+    """Settings for connecting to Kafka."""
+
+    bootstrap_servers: str = Field(
+        ...,
+        title="Kafka bootstrap servers",
+        env="KAFKA_BOOTSTRAP_SERVERS",
+        description=(
+            "A comma-separated list of Kafka brokers to connect to. "
+            "This should be a list of hostnames or IP addresses, "
+            "each optionally followed by a port number, separated by "
+            "commas. "
+            "For example: `kafka-1:9092,kafka-2:9092,kafka-3:9092`."
+        ),
+    )
+
+    security_protocol: KafkaSecurityProtocol = Field(
+        KafkaSecurityProtocol.PLAINTEXT,
+        env="KAFKA_SECURITY_PROTOCOL",
+        description="The security protocol to use when connecting to Kafka.",
+    )
+
+    cert_temp_dir: DirectoryPath | None = Field(
+        None,
+        env="KAFKA_CERT_TEMP_DIR",
+        description=(
+            "Temporary writable directory for concatenating certificates."
+        ),
+    )
+
+    cluster_ca_path: FilePath | None = Field(
+        None,
+        title="Path to CA certificate file",
+        env="KAFKA_SSL_CLUSTER_CAFILE",
+        description=(
+            "The path to the CA certificate file to use for verifying the "
+            "broker's certificate. "
+            "This is only needed if the broker's certificate is not signed "
+            "by a CA trusted by the operating system."
+        ),
+    )
+
+    client_ca_path: FilePath | None = Field(
+        None,
+        title="Path to client CA certificate file",
+        env="KAFKA_SSL_CLIENT_CAFILE",
+        description=(
+            "The path to the client CA certificate file to use for "
+            "authentication. "
+            "This is only needed when the client certificate needs to be"
+            "concatenated with the client CA certificate, which is common"
+            "for Strimzi installations."
+        ),
+    )
+
+    client_cert_path: FilePath | None = Field(
+        None,
+        title="Path to client certificate file",
+        env="KAFKA_SSL_CLIENT_CERTFILE",
+        description=(
+            "The path to the client certificate file to use for "
+            "authentication. "
+            "This is only needed if the broker is configured to require "
+            "SSL client authentication."
+        ),
+    )
+
+    client_key_path: FilePath | None = Field(
+        None,
+        title="Path to client key file",
+        env="KAFKA_SSL_CLIENT_KEYFILE",
+        description=(
+            "The path to the client key file to use for authentication. "
+            "This is only needed if the broker is configured to require "
+            "SSL client authentication."
+        ),
+    )
+
+    client_key_password: SecretStr | None = Field(
+        None,
+        title="Password for client key file",
+        env="KAFKA_SSL_CLIENT_KEY_PASSWORD",
+        description=(
+            "The password to use for decrypting the client key file. "
+            "This is only needed if the client key file is encrypted."
+        ),
+    )
+
+    sasl_mechanism: KafkaSaslMechanism | None = Field(
+        KafkaSaslMechanism.PLAIN,
+        title="SASL mechanism",
+        env="KAFKA_SASL_MECHANISM",
+        description=(
+            "The SASL mechanism to use for authentication. "
+            "This is only needed if SASL authentication is enabled."
+        ),
+    )
+
+    sasl_username: str | None = Field(
+        None,
+        title="SASL username",
+        env="KAFKA_SASL_USERNAME",
+        description=(
+            "The username to use for SASL authentication. "
+            "This is only needed if SASL authentication is enabled."
+        ),
+    )
+
+    sasl_password: SecretStr | None = Field(
+        None,
+        title="SASL password",
+        env="KAFKA_SASL_PASSWORD",
+        description=(
+            "The password to use for SASL authentication. "
+            "This is only needed if SASL authentication is enabled."
+        ),
+    )
+
+    @property
+    def ssl_context(self) -> SSLContext | None:
+        """An SSL context for connecting to Kafka with aiokafka, if the
+        Kafka connection is configured to use SSL.
+        """
+        if (
+            self.security_protocol != KafkaSecurityProtocol.SSL
+            or self.cluster_ca_path is None
+            or self.client_cert_path is None
+            or self.client_key_path is None
+        ):
+            return None
+
+        # For type checking
+        assert self.client_cert_path is not None
+        assert self.cluster_ca_path is not None
+        assert self.client_key_path is not None
+
+        client_cert_path = Path(self.client_cert_path)
+
+        if self.client_ca_path is not None:
+            # Need to contatenate the client cert and CA certificates. This is
+            # typical for Strimzi-based Kafka clusters.
+            if self.cert_temp_dir is None:
+                raise RuntimeError(
+                    "KAFKIT_KAFKA_CERT_TEMP_DIR must be set when "
+                    "a client CA certificate is provided."
+                )
+            client_ca = Path(self.client_ca_path).read_text()
+            client_cert = Path(self.client_cert_path).read_text()
+            if client_ca.endswith("\n"):
+                sep = ""
+            else:
+                sep = "\n"
+            new_client_cert = sep.join([client_cert, client_ca])
+            new_client_cert_path = Path(self.cert_temp_dir) / "client.crt"
+            new_client_cert_path.write_text(new_client_cert)
+            client_cert_path = Path(new_client_cert_path)
+
+        return create_ssl_context(
+            cluster_ca_path=Path(self.cluster_ca_path),
+            client_cert_path=client_cert_path,
+            client_key_path=Path(self.client_key_path),
+        )


### PR DESCRIPTION
This new module provides the `KafkaConnectionSettings` module we built in Squarebot. This class, built with Pydantic's BaseSettings provides a consistent framework for gathering Kafka client configurations from an app's environment variables. It also provides a ready-to-use SSLContext if TLS certs are included in the configuration.