### PR TITLE
Move from cgi.parse_header to email.message.Message parsing

### DIFF
--- a/src/kafkit/httputils.py
+++ b/src/kafkit/httputils.py
@@ -4,9 +4,9 @@ This code is based on on the sans-io code of Gidgethub
 (https://github.com/brettcannon/gidgethub) and generalized for Kafkit.
 """
 
-import cgi
 import urllib.parse
 from collections.abc import Mapping
+from email.message import Message
 
 import uritemplate
 
@@ -50,6 +50,6 @@ def parse_content_type(
     if content_type is None:
         return None, "utf-8"
     else:
-        type_, parameters = cgi.parse_header(content_type)
-        encoding = parameters.get("charset", "utf-8")
-        return type_, encoding
+        m = Message()
+        m["content-type"] = content_type
+        return m.get_content_type(), m.get_param("charset", "utf-8")

--- a/tests/httputils_test.py
+++ b/tests/httputils_test.py
@@ -1,6 +1,5 @@
 """Tests for the kafkit.utils module."""
 
-
 import pytest
 
 from kafkit.httputils import format_url


### PR DESCRIPTION
I made this PR because kafkit isn't python 3.13 compatible (due to importing cgi, which is removed from python at 3.13).
[PEP 594](https://peps.python.org/pep-0594/#cgi ) suggests replacing cgi.parse_header() with use of email.message.Message, which is what I've done here. 

SAFIR uses py3.13, so this was causing Wil a tiny bit of trouble for OBSLOCTAP. He worked around it, but it seems like a small change to make so that he can just build without modifying kafkit or its build packaging (it's possible to import cgi-legacy, but this is not part of the build requirements so also has to be done by hand).

I had a bit of trouble running tox locally - pydantic is unhappy.