### PR TITLE
DM-55493: Ruff configured via shared ruff-shared.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,92 +115,22 @@ warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
 
-# The rule used with Ruff configuration is to disable every lint that has
-# legitimate exceptions that are not dodgy code, rather than cluttering code
-# with noqa markers. This is therefore a reiatively relaxed configuration that
-# errs on the side of disabling legitimate lints.
-#
-# Reference for settings: https://beta.ruff.rs/docs/settings/
-# Reference for rules: https://beta.ruff.rs/docs/rules/
 [tool.ruff]
-exclude = [
-    "docs/**",
-]
-line-length = 79
-ignore = [
-    "ANN101",  # self should not have a type annotation
-    "ANN102",  # cls should not have a type annotation
-    "ANN401",  # sometimes Any is the right type
-    "ARG001",  # unused function arguments are often legitimate
-    "ARG002",  # unused method arguments are often legitimate
-    "ARG005",  # unused lambda arguments are often legitimate
-    "BLE001",  # we want to catch and report Exception in background tasks
-    "C414",    # nested sorted is how you sort by multiple keys with reverse
-    "COM812",  # omitting trailing commas allows black autoreformatting
-    "D102",    # sometimes we use docstring inheritence
-    "D104",    # don't see the point of documenting every package
-    "D105",    # our style doesn't require docstrings for magic methods
-    "D106",    # Pydantic uses a nested Config class that doesn't warrant docs
-    "D205",    # Allow multi-line summary sentences
-    "EM101",   # justification (duplicate string in traceback) is silly
-    "EM102",   # justification (duplicate string in traceback) is silly
-    "FBT003",  # positional booleans are normal for Pydantic field defaults
-    "G004",    # forbidding logging f-strings is appealing, but not our style
-    "RET505",  # disagree that omitting else always makes code more readable
-    "PLR0913", # factory pattern uses constructors with many arguments
-    "PLR2004", # too aggressive about magic values
-    "S105",    # good idea but too many false positives on non-passwords
-    "S106",    # good idea but too many false positives on non-passwords
-    "SIM102",  # sometimes the formatting of nested if statements is clearer
-    "SIM116",  # allow if-else-if-else chains
-    "SIM117",  # sometimes nested with contexts are clearer
-    "TCH001",  # we decided to not maintain separate TYPE_CHECKING blocks
-    "TCH002",  # we decided to not maintain separate TYPE_CHECKING blocks
-    "TCH003",  # we decided to not maintain separate TYPE_CHECKING blocks
-    "TID252",  # if we're going to use relative imports, use them always
-    "TRY003",  # good general advice but lint is way too aggressive
-]
-select = ["ALL"]
-target-version = "py310"
+extend = "ruff-shared.toml"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint]
+extend-ignore = [
+    "SIM116",  # allow if-else-if-else chains
+]
+
+[tool.ruff.lint.extend-per-file-ignores]
 "tests/**" = [
-    "D103",    # tests don't need docstrings
-    "PLR0915", # tests are allowed to be long, sometimes that's convenient
-    "PT012",   # way too aggressive about limiting pytest.raises blocks
-    "S101",    # tests should use assert
-    "SLF001",  # tests are allowed to access private members
     "T201",    # Print is ok in tests
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["kafkit", "tests"]
 split-on-trailing-comma = false
-
-# These are too useful as attributes or methods to allow the conflict with the
-# built-in to rule out their use.
-[tool.ruff.flake8-builtins]
-builtins-ignorelist = [
-    "all",
-    "any",
-    "help",
-    "id",
-    "list",
-    "type",
-]
-
-[tool.ruff.flake8-pytest-style]
-fixture-parentheses = false
-mark-parentheses = false
-
-[tool.ruff.pep8-naming]
-classmethod-decorators = [
-    "pydantic.root_validator",
-    "pydantic.validator",
-]
-
-[tool.ruff.pydocstyle]
-convention = "numpy"
 
 [tool.scriv]
 categories = [

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -1,0 +1,154 @@
+# Generic shared Ruff configuration file. It should be possible to use this
+# file unmodified in different packages provided that one likes the style that
+# it enforces.
+#
+# This file should be used from pyproject.toml as follows:
+#
+#     [tool.ruff]
+#     extend = "ruff-shared.toml"
+#
+# It can then be extended with project-specific rules. A common additional
+# setting in pyproject.toml is tool.ruff.lint.extend-per-file-ignores, to add
+# additional project-specific ignore rules for specific paths.
+#
+# The rule used with Ruff configuration is to disable every non-deprecated
+# lint rule that has legitimate exceptions that are not dodgy code, rather
+# than cluttering code with noqa markers. This is therefore a reiatively
+# relaxed configuration that errs on the side of disabling legitimate rules.
+#
+# Reference for settings: https://docs.astral.sh/ruff/settings/
+# Reference for rules: https://docs.astral.sh/ruff/rules/
+exclude = ["docs/**"]
+line-length = 79
+
+[format]
+docstring-code-format = true
+
+[lint]
+ignore = [
+    "A005",     # we always use relative imports so this is not ambiguous
+    "ANN401",   # sometimes Any is the right type
+    "ARG001",   # unused function arguments are often legitimate
+    "ARG002",   # unused method arguments are often legitimate
+    "ARG003",   # unused class method arguments are often legitimate
+    "ARG005",   # unused lambda arguments are often legitimate
+    "ASYNC109", # many async functions use asyncio.timeout internally
+    "ASYNC240", # we don't want to run filesystem operations on threads
+    "BLE001",   # we want to catch and report Exception in background tasks
+    "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "D102",     # sometimes we use docstring inheritence
+    "D104",     # don't see the point of documenting every package
+    "D105",     # our style doesn't require docstrings for magic methods
+    "D106",     # Pydantic uses a nested Config class that doesn't warrant docs
+    "D205",     # our documentation style allows a folded first line
+    "EM101",    # justification (duplicate string in traceback) is silly
+    "EM102",    # justification (duplicate string in traceback) is silly
+    "FBT003",   # positional booleans are normal for Pydantic field defaults
+    "FIX002",   # point of a TODO comment is that we're not ready to fix it
+    "PD011",    # attempts to enforce pandas conventions for all data types
+    "G004",     # forbidding logging f-strings is appealing, but not our style
+    "RET505",   # disagree that omitting else always makes code more readable
+    "PLR0911",  # often many returns is clearer and simpler style
+    "PLR0913",  # factory pattern uses constructors with many arguments
+    "PLR2004",  # too aggressive about magic values
+    "PLW0603",  # yes global is discouraged but if needed, it's needed
+    "S105",     # good idea but too many false positives on non-passwords
+    "S106",     # good idea but too many false positives on non-passwords
+    "S107",     # good idea but too many false positives on non-passwords
+    "S603",     # not going to manually mark every subprocess call as reviewed
+    "S607",     # using PATH is not a security vulnerability
+    "SIM102",   # sometimes the formatting of nested if statements is clearer
+    "SIM117",   # sometimes nested with contexts are clearer
+    "TC001",    # we decided to not maintain separate TYPE_CHECKING blocks
+    "TC002",    # we decided to not maintain separate TYPE_CHECKING blocks
+    "TC003",    # we decided to not maintain separate TYPE_CHECKING blocks
+    "TD003",    # we don't require issues be created for TODOs
+    "TID252",   # if we're going to use relative imports, use them always
+    "TRY003",   # good general advice but lint is way too aggressive
+    "TRY301",   # sometimes raising exceptions inside try is the best flow
+    "UP040",    # PEP 695 type aliases not yet supported by mypy
+
+    # The following settings should be disabled when using ruff format
+    # per https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
+]
+select = ["ALL"]
+
+[lint.per-file-ignores]
+"alembic/**" = [
+    "INP001",  # Alembic files are magical
+    "D103",    # Alembic methods do not need docstrings
+    "D400",    # Alembic migrations have their own docstring format
+]
+"noxfile.py" = [
+    "T201",    # print makes sense as output from nox rules
+]
+"src/*/handlers/**" = [
+    "D103",    # FastAPI handlers should not have docstrings
+]
+"*/src/*/handlers/**" = [
+    "D103",    # FastAPI handlers should not have docstrings
+]
+"tests/**" = [
+    "C901",    # tests are allowed to be complex, sometimes that's convenient
+    "D101",    # tests don't need docstrings
+    "D103",    # tests don't need docstrings
+    "PLR0915", # tests are allowed to be long, sometimes that's convenient
+    "PT012",   # way too aggressive about limiting pytest.raises blocks
+    "S101",    # tests should use assert
+    "S106",    # tests are allowed to hard-code dummy passwords
+    "S301",    # allow tests for whether code can be pickled
+    "SLF001",  # tests are allowed to access private members
+]
+"*/tests/**" = [
+    "C901",    # tests are allowed to be complex, sometimes that's convenient
+    "D101",    # tests don't need docstrings
+    "D103",    # tests don't need docstrings
+    "PLR0915", # tests are allowed to be long, sometimes that's convenient
+    "PT012",   # way too aggressive about limiting pytest.raises blocks
+    "S101",    # tests should use assert
+    "S106",    # tests are allowed to hard-code dummy passwords
+    "S301",    # allow tests for whether code can be pickled
+    "SLF001",  # tests are allowed to access private members
+]
+"tests/schema_test.py" = [
+    "ASYNC221", # useful to run subprocess in async tests for Alembic
+]
+"*/tests/schema_test.py" = [
+    "ASYNC221", # useful to run subprocess in async tests for Alembic
+]
+
+# These are too useful as attributes or methods to allow the conflict with the
+# built-in to rule out their use.
+[lint.flake8-builtins]
+builtins-ignorelist = [
+    "all",
+    "any",
+    "help",
+    "id",
+    "list",
+    "type",
+]
+
+[lint.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+
+[lint.isort]
+split-on-trailing-comma = false
+
+[lint.pydocstyle]
+convention = "numpy"

--- a/src/kafkit/fastapi/dependencies/aiokafkaproducer.py
+++ b/src/kafkit/fastapi/dependencies/aiokafkaproducer.py
@@ -4,7 +4,7 @@ import aiokafka  # patched for testing
 
 from kafkit.settings import KafkaConnectionSettings
 
-__all__ = ["kafka_producer_dependency", "AioKafkaProducerDependency"]
+__all__ = ["AioKafkaProducerDependency", "kafka_producer_dependency"]
 
 
 class AioKafkaProducerDependency:

--- a/src/kafkit/fastapi/dependencies/pydanticschemamanager.py
+++ b/src/kafkit/fastapi/dependencies/pydanticschemamanager.py
@@ -11,8 +11,8 @@ from kafkit.registry import manager  # this is patched in tests
 from kafkit.registry.httpx import RegistryApi
 
 __all__ = [
-    "pydantic_schema_manager_dependency",
     "PydanticSchemaManagerDependency",
+    "pydantic_schema_manager_dependency",
 ]
 
 

--- a/src/kafkit/fastapi/dependencies/registryapi.py
+++ b/src/kafkit/fastapi/dependencies/registryapi.py
@@ -4,7 +4,7 @@ from httpx import AsyncClient
 
 from kafkit.registry.httpx import RegistryApi
 
-__all__ = ["registry_api_dependency", "RegistryApiDependency"]
+__all__ = ["RegistryApiDependency", "registry_api_dependency"]
 
 
 class RegistryApiDependency:

--- a/src/kafkit/registry/__init__.py
+++ b/src/kafkit/registry/__init__.py
@@ -20,12 +20,12 @@ from kafkit.registry.serializer import (
 __all__ = [
     "Deserializer",
     "MessageInfo",
-    "Serializer",
     "PolySerializer",
     "RegistryBadRequestError",
     "RegistryBrokenError",
     "RegistryError",
     "RegistryHttpError",
     "RegistryRedirectionError",
+    "Serializer",
     "UnmanagedSchemaError",
 ]

--- a/src/kafkit/registry/errors.py
+++ b/src/kafkit/registry/errors.py
@@ -1,11 +1,11 @@
 """Exceptions classes for the Registry client."""
 
 __all__ = [
+    "RegistryBadRequestError",
+    "RegistryBrokenError",
     "RegistryError",
     "RegistryHttpError",
     "RegistryRedirectionError",
-    "RegistryBadRequestError",
-    "RegistryBrokenError",
     "UnmanagedSchemaError",
 ]
 

--- a/src/kafkit/registry/manager/__init__.py
+++ b/src/kafkit/registry/manager/__init__.py
@@ -5,4 +5,4 @@ serialization and deserialization of messages.
 from ._pydantic import PydanticSchemaManager
 from ._recordname import RecordNameSchemaManager
 
-__all__ = ["RecordNameSchemaManager", "PydanticSchemaManager"]
+__all__ = ["PydanticSchemaManager", "RecordNameSchemaManager"]

--- a/src/kafkit/registry/sansio.py
+++ b/src/kafkit/registry/sansio.py
@@ -28,14 +28,14 @@ from .errors import (
 )
 
 __all__ = [
-    "make_headers",
-    "decipher_response",
-    "decode_body",
-    "RegistryApi",
+    "CompatibilityType",
     "MockRegistryApi",
+    "RegistryApi",
     "SchemaCache",
     "SubjectCache",
-    "CompatibilityType",
+    "decipher_response",
+    "decode_body",
+    "make_headers",
 ]
 
 
@@ -644,7 +644,7 @@ class MockRegistryApi(RegistryApi):
     ) -> None:
         super().__init__(url=url)
         self.response_code = status_code
-        self.response_headers = headers if headers else self._default_headers
+        self.response_headers = headers or self._default_headers
         self.response_body = body
 
     async def _request(

--- a/src/kafkit/registry/serializer.py
+++ b/src/kafkit/registry/serializer.py
@@ -15,10 +15,10 @@ if TYPE_CHECKING:
     from kafkit.registry.sansio import RegistryApi
 
 __all__ = [
-    "Serializer",
-    "PolySerializer",
     "Deserializer",
     "MessageInfo",
+    "PolySerializer",
+    "Serializer",
 ]
 
 

--- a/src/kafkit/settings.py
+++ b/src/kafkit/settings.py
@@ -12,8 +12,8 @@ from .ssl import create_ssl_context
 
 __all__ = [
     "KafkaConnectionSettings",
-    "KafkaSecurityProtocol",
     "KafkaSaslMechanism",
+    "KafkaSecurityProtocol",
 ]
 
 

--- a/tests/registry_manager_test.py
+++ b/tests/registry_manager_test.py
@@ -1,6 +1,7 @@
 """Tests for the kafkit.registry.manager module."""
 
 import os
+import re
 from pathlib import Path
 
 import pytest
@@ -44,6 +45,6 @@ async def test_recordnameschemamanager() -> None:
         # Sanity check that you can't serialize with the wrong schema!
         with pytest.raises(
             ValueError,
-            match=("Cannot serialize data with schema kafkit.a"),
+            match=re.escape("Cannot serialize data with schema kafkit.a"),
         ):
             await manager.serialize(data=topic_b_message, name="kafkit.a")

--- a/tests/registry_sansio_test.py
+++ b/tests/registry_sansio_test.py
@@ -401,12 +401,12 @@ def test_subject_cache() -> None:
         cache.insert("schema3", 13)
     with pytest.raises(
         ValueError,
-        match="^Trying to cache the schema ID for subject 'schema3'",
+        match=r"^Trying to cache the schema ID for subject 'schema3'",
     ):
         cache.insert("schema3", 13, schema_id=3)
     with pytest.raises(
         ValueError,
-        match="^Trying to cache the schema ID for subject 'schema3'",
+        match=r"^Trying to cache the schema ID for subject 'schema3'",
     ):
         cache.insert("schema3", 13, schema=schema3)
     cache.insert("schema3", 13, schema=schema3, schema_id=3)
@@ -417,17 +417,17 @@ def test_subject_cache() -> None:
     # Test getting a non-existent subject or version
     with pytest.raises(
         ValueError,
-        match="Schema with subject 'schema3' version 25 not cached.",
+        match=r"Schema with subject 'schema3' version 25 not cached.",
     ):
         cache.get_id("schema3", 25)
     with pytest.raises(
         ValueError,
-        match="Schema with subject 'schema18' version 25 not cached.",
+        match=r"Schema with subject 'schema18' version 25 not cached.",
     ):
         cache.get_schema("schema18", 25)
     with pytest.raises(
         ValueError,
-        match="Schema with subject 'schema18' version 15 not cached.",
+        match=r"Schema with subject 'schema18' version 15 not cached.",
     ):
         cache.get("schema18", 15)
 


### PR DESCRIPTION
## Summary

- Adopt the lsst-sqre shared `ruff-shared.toml` (copied from `lsst/templates` `project_templates/square_pypi_package`) instead of kafkit's fully inline `[tool.ruff]` config in `pyproject.toml`.
- `pyproject.toml` now uses `extend = "ruff-shared.toml"`, keeping only repo-specific bits: isort `known-first-party`, a `tests/**` ignore for `T201` (print), and an `extend-ignore` for `SIM116` (if/elif chains), matching this repo's prior style choices.
- Fixed the handful of new findings surfaced by the shared config's broader ruleset: sorted `__all__` lists (RUF022, auto-fixed), an or-expression simplification (FURB110, auto-fixed), and raw-string `match=` patterns in `pytest.raises` (RUF043).

`ruff check .` passes clean.

## Test plan

- [x] `ruff check .` passes with no findings
- [ ] CI (lint/tests) green on this PR

Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ